### PR TITLE
Faster dataset `__getitem__`, use workers

### DIFF
--- a/train.py
+++ b/train.py
@@ -67,7 +67,7 @@ argparser.add_argument(
 )
 argparser.add_argument("--mask_ratio", type=float, default=0.75)
 argparser.add_argument("--seed", type=int, default=DEFAULT_SEED)
-argparser.add_argument("--num_workers", type=int, default=0)
+argparser.add_argument("--num_workers", type=int, default=4)
 argparser.add_argument("--wandb", dest="wandb", action="store_true")
 argparser.add_argument("--wandb_org", type=str, default="nasa-harvest")
 argparser.add_argument(

--- a/train.py
+++ b/train.py
@@ -67,6 +67,7 @@ argparser.add_argument(
 )
 argparser.add_argument("--mask_ratio", type=float, default=0.75)
 argparser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+argparser.add_argument("--num_workers", type=int, default=0)
 argparser.add_argument("--wandb", dest="wandb", action="store_true")
 argparser.add_argument("--wandb_org", type=str, default="nasa-harvest")
 argparser.add_argument(
@@ -86,6 +87,7 @@ args = argparser.parse_args().__dict__
 
 model_name = args["model_name"]
 seed: int = args["seed"]
+num_workers: int = args["num_workers"]
 path_to_config = args["path_to_config"]
 warm_start = args["warm_start"]
 wandb_enabled: bool = args["wandb"]
@@ -138,10 +140,16 @@ mask_params = MaskParamsNoDw(mask_strategies, mask_ratio)
 train_df = pd.read_parquet(data_dir / train_file)
 val_df = pd.read_parquet(data_dir / val_file)
 train_dataloader = DataLoader(
-    WorldCerealDataset(train_df, mask_params=mask_params), batch_size=batch_size, shuffle=True
+    WorldCerealDataset(train_df, mask_params=mask_params),
+    batch_size=batch_size,
+    shuffle=True,
+    num_workers=num_workers,
 )
 val_dataloader = DataLoader(
-    WorldCerealDataset(val_df, mask_params=mask_params), batch_size=batch_size, shuffle=False
+    WorldCerealDataset(val_df, mask_params=mask_params),
+    batch_size=batch_size,
+    shuffle=False,
+    num_workers=num_workers,
 )
 validation_task = WorldCerealEval(
     train_data=train_df.sample(1000, random_state=DEFAULT_SEED),


### PR DESCRIPTION
Working on #2.

This is the profiler output before any changes. A train step took ~35s on my machine (for a smaller batch size of 2048), with the number of dataset workers set to 0.
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000  208.387  208.387 /home/rubenc/.pycharm_helpers/profiler/prof_util.py:15(execfile)
   3408/1    0.083    0.000  208.382  208.382 {built-in method builtins.exec}
        1    0.012    0.012  208.382  208.382 train.py:2(<module>)
       15    0.000    0.000  191.082   12.739 /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/venv/lib/python3.9/site-packages/tqdm/std.py:1174(__iter__)
       12    0.000    0.000  191.063   15.922 /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/venv/lib/python3.9/site-packages/torch/utils/data/dataloader.py:629(__next__)
       12    0.012    0.001  191.060   15.922 /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/venv/lib/python3.9/site-packages/torch/utils/data/dataloader.py:676(_next_data)
       12    0.000    0.000  190.987   15.916 /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/venv/lib/python3.9/site-packages/torch/utils/data/_utils/fetch.py:46(fetch)
       12    0.134    0.011  190.535   15.878 /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/venv/lib/python3.9/site-packages/torch/utils/data/_utils/fetch.py:51(<listcomp>)
    24576    0.371    0.000  190.401    0.008 /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/src/dataset.py:82(__getitem__)
    24576    7.492    0.000  175.452    0.007 /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/src/dataset.py:22(row_to_arrays)
   491520    1.898    0.000  160.768    0.000 /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/venv/lib/python3.9/site-packages/pandas/core/series.py:928(__getitem__)
   344064    1.298    0.000  154.169    0.000 /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/venv/lib/python3.9/site-packages/pandas/core/series.py:968(_get_with)
   368640    0.899    0.000  154.052    0.000 /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/venv/lib/python3.9/site-packages/pandas/core/indexing.py:918(__getitem__)
   344064    2.020    0.000  143.817    0.000 /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/venv/lib/python3.9/site-packages/pandas/core/indexing.py:1132(_getitem_axis)
   344064    1.308    0.000  138.807    0.000 /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/venv/lib/python3.9/site-packages/pandas/core/indexing.py:1067(_getitem_iterable)
   344064    2.435    0.000  110.152    0.000 /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/venv/lib/python3.9/site-packages/pandas/core/indexing.py:1267(_get_listlike_indexer)
   688128    3.284    0.000   66.511    0.000 /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/venv/lib/python3.9/site-packages/pandas/core/indexes/base.py:3426(get_indexer)
   344064    1.803    0.000   49.562    0.000 /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/venv/lib/python3.9/site-packages/pandas/core/indexes/base.py:3787(reindex)
   344064    0.691    0.000   47.175    0.000 /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/venv/lib/python3.9/site-packages/pandas/core/indexes/base.py:5261(get_indexer_for)
  1400838    1.720    0.000   47.040    0.000 /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/venv/lib/python3.9/site-packages/pandas/core/indexes/base.py:6279(ensure_index)
688132/688130    7.805    0.000   44.419    0.000 /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/venv/lib/python3.9/site-packages/pandas/core/indexes/base.py:375(__new__)
   344064    2.362    0.000   27.133    0.000 /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/venv/lib/python3.9/site-packages/pandas/core/generic.py:4860(_reindex_with_indexers)
   688128    0.328    0.000   24.856    0.000 /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/venv/lib/python3.9/site-packages/pandas/core/indexes/base.py:5704(_maybe_cast_listlike_indexer)
   688130    1.828    0.000   19.570    0.000 /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/venv/lib/python3.9/site-packages/pandas/core/indexes/base.py:6397(_maybe_cast_data_without_dtype)
```
As you already suggested `row_to_array` takes most of the time, so zooming in on that function:
```
Function                                                                               called...
                                                                                           ncalls  tottime  cumtime
/cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/src/dataset.py:22(row_to_arrays)  ->  344064    0.998    2.570  /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/src/dataset.py:45(<listcomp>)
                                                                                            73728    0.153    1.401  /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/venv/lib/python3.9/site-packages/pandas/core/generic.py:5473(__getattr__)
                                                                                           344064    0.249    1.429  /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/venv/lib/python3.9/site-packages/pandas/core/series.py:632(values)
                                                                                           417792    1.744  159.984  /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/venv/lib/python3.9/site-packages/pandas/core/series.py:928(__getitem__)
                                                                                            24576    0.004    0.004  {built-in method builtins.len}
                                                                                            24576    0.073    0.073  {built-in method numpy.array}
                                                                                            24576    0.056    0.056  {built-in method numpy.zeros}
                                                                                            24576    0.039    0.743  {built-in method strptime}
                                                                                           344064    1.490    1.490  {method 'astype' of 'numpy.ndarray' objects}
                                                                                           393216    0.200    0.200  {method 'index' of 'list' objects}
                                                                                            49152    0.010    0.010  {method 'items' of 'dict' objects}
```
It seems like `pd.Series.__getitem__` takes by far most time within `row_to_array`, which is somewhat surprising to me. 
Some people mention ([1](https://stackoverflow.com/questions/45783891/is-there-a-way-to-speed-up-the-pandas-getitem-getitem-axis-and-get-label), [2](https://stackoverflow.com/questions/53997424/why-is-pandas-indexing-so-slow-how-to-make-it-faster)) that `__getitem__` in pandas has a lot of overhead to support fancy indexing with lists and iterables, so I converted the row to a python dict with `row_d = pd.Series.to_dict(row)` and indexed the dict in `row_to_array`.

A training step now takes ~2.5 seconds (still with 0 workers), an epoch around 11 min, but GPU utilization still below 10%.
This is the profile output:
```
  ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   39.974   39.974 /home/rubenc/.pycharm_helpers/profiler/prof_util.py:15(execfile)
   3501/1    0.090    0.000   39.968   39.968 {built-in method builtins.exec}
        1    0.012    0.012   39.968   39.968 train.py:2(<module>)
       15    0.000    0.000   25.449    1.697 /cw/liir/NoCsBack/testliir/rubenc/miniconda3/envs/cerealenv9/lib/python3.9/site-packages/tqdm/std.py:1174(__iter__)
       12    0.000    0.000   25.435    2.120 /cw/liir/NoCsBack/testliir/rubenc/miniconda3/envs/cerealenv9/lib/python3.9/site-packages/torch/utils/data/dataloader.py:629(__next__)
       12    0.012    0.001   25.433    2.119 /cw/liir/NoCsBack/testliir/rubenc/miniconda3/envs/cerealenv9/lib/python3.9/site-packages/torch/utils/data/dataloader.py:676(_next_data)
       12    0.000    0.000   25.356    2.113 /cw/liir/NoCsBack/testliir/rubenc/miniconda3/envs/cerealenv9/lib/python3.9/site-packages/torch/utils/data/_utils/fetch.py:46(fetch)
       12    0.131    0.011   24.750    2.062 /cw/liir/NoCsBack/testliir/rubenc/miniconda3/envs/cerealenv9/lib/python3.9/site-packages/torch/utils/data/_utils/fetch.py:51(<listcomp>)
    24576    0.402    0.000   24.618    0.001 /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/src/dataset.py:91(__getitem__)
    24576    1.208    0.000    9.739    0.000 /cw/liir/NoCsBack/testliir/rubenc/presto-worldcereal/src/dataset.py:22(row_to_arrays)
    24576    0.121    0.000    9.325    0.000 /cw/liir/NoCsBack/testliir/rubenc/miniconda3/envs/cerealenv9/lib/python3.9/site-packages/pandas/core/indexing.py:918(__getitem__)
    24576    0.098    0.000    8.969    0.000 /cw/liir/NoCsBack/testliir/rubenc/miniconda3/envs/cerealenv9/lib/python3.9/site-packages/pandas/core/indexing.py:1504(_getitem_tuple)
    24576    0.169    0.000    8.330    0.000 /cw/liir/NoCsBack/testliir/rubenc/miniconda3/envs/cerealenv9/lib/python3.9/site-packages/pandas/core/indexing.py:813(_getitem_lowerdim)
    24576    0.088    0.000    7.912    0.000 /cw/liir/NoCsBack/testliir/rubenc/miniconda3/envs/cerealenv9/lib/python3.9/site-packages/pandas/core/indexing.py:1535(_getitem_axis)
    24576    0.147    0.000    7.624    0.000 /cw/liir/NoCsBack/testliir/rubenc/miniconda3/envs/cerealenv9/lib/python3.9/site-packages/pandas/core/frame.py:3366(_ixs)
  3222/20    0.021    0.000    5.956    0.298 <frozen importlib._bootstrap>:1002(_find_and_load)
```
`row_to_array` still takes significant time, but it seems a lot better already :-). `{method 'run_backward' of 'torch._C._EngineBase' objects}` only appears quite low in the list.

Now setting `num_workers` to 8 (can't profile anymore since the profiler doesn't show the work done by the worker processes): 1.7 iterations/s (instead of s/iteration), an epoch takes 2 minutes, GPU utilization over 70%. Here's a [wandb run](https://wandb.ai/nasa-harvest/presto-worldcereal/runs/qwab5eyc/).

I do think we can probably speed this up more by precomputing the arrays, but for development I kind of prefer the idea of computing the input on the fly, so we can easily change the inputs. Let me know if you disagree!