### PR TITLE
Masking with the real masks

### DIFF
--- a/src/dataset.py
+++ b/src/dataset.py
@@ -81,7 +81,7 @@ class WorldCerealBase(Dataset):
         for df_val, presto_val in cls.STATIC_BAND_MAPPING.items():
             eo_data[:, BANDS.index(presto_val)] = row_d[df_val]
 
-        return eo_data, mask_per_token, latlon, month, row_d["LANDCOVER_LABEL"] == 11
+        return eo_data, mask_per_token.astype(bool), latlon, month, row_d["LANDCOVER_LABEL"] == 11
 
     def __getitem__(self, idx):
         raise NotImplementedError

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -63,7 +63,7 @@ class WorldCerealBase(Dataset):
         # have the same masking
         mask_per_token = np.zeros((cls.NUM_TIMESTEPS, len(BANDS_GROUPS_IDX)))
         for df_val, presto_val in cls.BAND_MAPPING.items():
-            values = [float(row_d[df_val.format(t)]) for t in range(cls.NUM_TIMESTEPS)]
+            values = np.array([float(row_d[df_val.format(t)]) for t in range(cls.NUM_TIMESTEPS)])
             idx_valid = values != cls._NODATAVALUE
             mask_per_token[:, IDX_TO_BAND_GROUPS[presto_val]] = np.clip(
                 mask_per_token[:, IDX_TO_BAND_GROUPS[presto_val]] + (~idx_valid), a_min=0, a_max=1

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -139,12 +139,14 @@ class WorldCerealLabelledDataset(WorldCerealBase):
         # Get the sample
         row = self.df.iloc[idx, :]
         eo, mask_per_token, latlon, month, target = self.row_to_arrays(row)
-        _ = np.repeat(mask_per_token, BAND_EXPANSION, axis=1)
-
+        mask_per_variable = np.repeat(mask_per_token, BAND_EXPANSION, axis=1)
+        num_masked_tokens = sum(sum(mask_per_token))
         return (
             self.normalize_and_mask(eo),
             target,
             np.ones(self.NUM_TIMESTEPS) * (DynamicWorld2020_2021.class_amount),
             latlon,
             month,
+            num_masked_tokens,
+            mask_per_variable,
         )

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -48,7 +48,7 @@ class WorldCerealBase(Dataset):
         return self.df.shape[0]
 
     @classmethod
-    def row_to_arrays(cls, row: pd.Series) -> Tuple[np.ndarray, np.ndarray, float, int]:
+    def row_to_arrays(cls, row: pd.Series) -> Tuple[np.ndarray, np.ndarray, np.ndarray, float, int]:
         # https://stackoverflow.com/questions/45783891/is-there-a-way-to-speed-up-the-pandas-getitem-getitem-axis-and-get-label
         # This is faster than indexing the series every time!
         row_d = pd.Series.to_dict(row)
@@ -64,7 +64,7 @@ class WorldCerealBase(Dataset):
             values = [float(row_d[df_val.format(t)]) for t in range(cls.NUM_TIMESTEPS)]
             idx_valid = values != cls._NODATAVALUE
             mask_per_token[:, IDX_TO_BAND_GROUPS[presto_val]] = np.clip(
-                mask_per_token[:, IDX_TO_BAND_GROUPS[presto_val]] + (~idx_valid), a_max=1
+                mask_per_token[:, IDX_TO_BAND_GROUPS[presto_val]] + (~idx_valid), a_min=0, a_max=1
             )
             if presto_val in ["VV", "VH"]:
                 # convert to dB

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -48,7 +48,9 @@ class WorldCerealBase(Dataset):
         return self.df.shape[0]
 
     @classmethod
-    def row_to_arrays(cls, row: pd.Series) -> Tuple[np.ndarray, np.ndarray, np.ndarray, float, int]:
+    def row_to_arrays(
+        cls, row: pd.Series
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, float, int]:
         # https://stackoverflow.com/questions/45783891/is-there-a-way-to-speed-up-the-pandas-getitem-getitem-axis-and-get-label
         # This is faster than indexing the series every time!
         row_d = pd.Series.to_dict(row)
@@ -104,7 +106,7 @@ class WorldCerealMaskedDataset(WorldCerealBase):
         row = self.df.iloc[idx, :]
         eo, real_mask_per_token, latlon, month, _ = self.row_to_arrays(row)
         mask_eo, x_eo, y_eo, strat = self.mask_params.mask_data(
-            self.normalize_and_mask(eo, real_mask_per_token)
+            self.normalize_and_mask(eo), real_mask_per_token
         )
         real_mask_per_variable = np.repeat(real_mask_per_token, BAND_EXPANSION, axis=1)
 

--- a/src/eval.py
+++ b/src/eval.py
@@ -44,7 +44,6 @@ class WorldCerealEval:
                 x_f, dw_f, latlons_f, month_f, variable_mask_f = [
                     t[filter].to(device) for t in (x, dw, latlons, month, variable_mask)
                 ]
-                target_list.append(y.cpu().numpy())
                 with torch.no_grad():
                     encodings = (
                         pretrained_model.encoder(

--- a/src/eval.py
+++ b/src/eval.py
@@ -3,7 +3,6 @@ from typing import Dict, List, Optional, Sequence, Union, cast
 import numpy as np
 import pandas as pd
 import torch
-from einops import repeat
 from sklearn.base import BaseEstimator, clone
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LogisticRegression
@@ -25,16 +24,6 @@ class WorldCerealEval:
         self.train_ds = train_data
         self.val_ds = val_data
 
-    @staticmethod
-    def _mask_to_batch_tensor(
-        mask: Optional[np.ndarray], batch_size: int
-    ) -> Optional[torch.Tensor]:
-        # TODO: This function should be replaced by a real mask,
-        # returned by the dataloader
-        if mask is not None:
-            return repeat(torch.from_numpy(mask).to(device), "t c -> b t c", b=batch_size).float()
-        return None
-
     @torch.no_grad()
     def finetune_sklearn_model(
         self,
@@ -48,19 +37,27 @@ class WorldCerealEval:
         pretrained_model.eval()
 
         encoding_list, target_list = [], []
-        for x, y, dw, latlons, month in tqdm(dl, desc="Computing embeddings"):
-            x, dw, latlons, y, month = [t.to(device) for t in (x, dw, latlons, y, month)]
-            batch_mask = self._mask_to_batch_tensor(mask, x.shape[0])
-            target_list.append(y.cpu().numpy())
-            with torch.no_grad():
-                encodings = (
-                    pretrained_model.encoder(
-                        x, dynamic_world=dw.long(), mask=batch_mask, latlons=latlons, month=month
+        for x, y, dw, latlons, month, num_masked_tokens, variable_mask in dl:
+            for masked_token_group in torch.unique(num_masked_tokens):
+                filter = num_masked_tokens == masked_token_group
+                target_list.append(y[filter].cpu().numpy())
+                x_f, dw_f, latlons_f, month_f, variable_mask_f = [
+                    t[filter].to(device) for t in (x, dw, latlons, month, variable_mask)
+                ]
+                target_list.append(y.cpu().numpy())
+                with torch.no_grad():
+                    encodings = (
+                        pretrained_model.encoder(
+                            x_f,
+                            dynamic_world=dw_f.long(),
+                            mask=variable_mask_f,
+                            latlons=latlons_f,
+                            month=month_f,
+                        )
+                        .cpu()
+                        .numpy()
                     )
-                    .cpu()
-                    .numpy()
-                )
-                encoding_list.append(encodings)
+                    encoding_list.append(encodings)
         encodings_np = np.concatenate(encoding_list)
         targets = np.concatenate(target_list)
         if len(targets.shape) == 2 and targets.shape[1] == 1:
@@ -98,32 +95,43 @@ class WorldCerealEval:
         )
 
         test_preds, targets = [], []
-        for x, y, dw, latlons, month in dl:
-            targets.append(y.cpu().numpy())
-            x, dw, latlons, month = [t.to(device) for t in (x, dw, latlons, month)]
-            batch_mask = self._mask_to_batch_tensor(mask, x.shape[0])
-            if isinstance(finetuned_model, PrestoFineTuningModel):
-                finetuned_model.eval()
-                preds = (
-                    finetuned_model(
-                        x, dynamic_world=dw.long(), mask=batch_mask, latlons=latlons, month=month
+        for x, y, dw, latlons, month, num_masked_tokens, variable_mask in dl:
+            for masked_token_group in torch.unique(num_masked_tokens):
+                filter = num_masked_tokens == masked_token_group
+                targets.append(y[filter].cpu().numpy())
+                x_f, dw_f, latlons_f, month_f, variable_mask_f = [
+                    t[filter].to(device) for t in (x, dw, latlons, month, variable_mask)
+                ]
+                if isinstance(finetuned_model, PrestoFineTuningModel):
+                    finetuned_model.eval()
+                    preds = (
+                        finetuned_model(
+                            x_f,
+                            dynamic_world=dw_f.long(),
+                            mask=variable_mask_f,
+                            latlons=latlons_f,
+                            month=month_f,
+                        )
+                        .squeeze(dim=1)
+                        .cpu()
+                        .numpy()
                     )
-                    .squeeze(dim=1)
-                    .cpu()
-                    .numpy()
-                )
-            elif isinstance(finetuned_model, BaseEstimator):
-                cast(Presto, pretrained_model).eval()
-                encodings = (
-                    cast(Presto, pretrained_model)
-                    .encoder(
-                        x, dynamic_world=dw.long(), mask=batch_mask, latlons=latlons, month=month
+                elif isinstance(finetuned_model, BaseEstimator):
+                    cast(Presto, pretrained_model).eval()
+                    encodings = (
+                        cast(Presto, pretrained_model)
+                        .encoder(
+                            x_f,
+                            dynamic_world=dw_f.long(),
+                            mask=variable_mask_f,
+                            latlons=latlons_f,
+                            month=month_f,
+                        )
+                        .cpu()
+                        .numpy()
                     )
-                    .cpu()
-                    .numpy()
-                )
-                preds = finetuned_model.predict(encodings)
-            test_preds.append(preds)
+                    preds = finetuned_model.predict(encodings)
+                test_preds.append(preds)
         test_preds_np = np.concatenate(test_preds) >= self.threshold
         target_np = np.concatenate(targets)
 

--- a/src/masking.py
+++ b/src/masking.py
@@ -89,7 +89,7 @@ def make_mask_no_dw(strategy: str, mask_ratio: float, existing_mask: np.ndarray)
         band_groups.remove(SRTM_INDEX)
         band_groups_to_mask = sample(band_groups, num_band_groups_to_mask)
         for band_group in band_groups_to_mask:
-            num_tokens_masked += int(len(mask[:, band_group]) - sum(mask[:, band_group]))
+            num_tokens_masked += int(len(mask[:, band_group] - sum(mask[:, band_group])))
             mask[:, band_group] = True
         num_tokens_to_mask += num_tokens_masked
         mask = random_masking(mask, num_tokens_to_mask)

--- a/src/masking.py
+++ b/src/masking.py
@@ -90,7 +90,7 @@ def make_mask_no_dw(strategy: str, mask_ratio: float, existing_mask: np.ndarray)
         band_groups.remove(SRTM_INDEX)
         band_groups_to_mask = sample(band_groups, num_band_groups_to_mask)
         for band_group in band_groups_to_mask:
-            num_tokens_masked += int(len(mask[:, band_group] - sum(mask[:, band_group])))
+            num_tokens_masked += int(len(mask[:, band_group]) - sum(mask[:, band_group]))
             mask[:, band_group] = True
         num_tokens_to_mask += num_tokens_masked
         mask = random_masking(mask, num_tokens_to_mask)

--- a/src/masking.py
+++ b/src/masking.py
@@ -50,6 +50,7 @@ def make_mask_no_dw(strategy: str, mask_ratio: float, existing_mask: np.ndarray)
     num_tokens_to_mask = int(
         ((NUM_TIMESTEPS * (len(BANDS_GROUPS_IDX) - 1)) + 1) * mask_ratio - sum(sum(mask))
     )
+    assert num_tokens_to_mask > 0
 
     def mask_topography(srtm_mask, num_tokens_to_mask, mask_ratio):
         should_flip = random() < mask_ratio

--- a/src/masking.py
+++ b/src/masking.py
@@ -48,8 +48,8 @@ def make_mask_no_dw(strategy: str, mask_ratio: float, existing_mask: np.ndarray)
     mask = existing_mask.copy()
     srtm_mask = False
     num_tokens_to_mask = int(
-        ((NUM_TIMESTEPS * (len(BANDS_GROUPS_IDX) - 1)) + 1) * mask_ratio
-    ) - sum(sum(mask))
+        ((NUM_TIMESTEPS * (len(BANDS_GROUPS_IDX) - 1)) + 1) * mask_ratio - sum(sum(mask))
+    )
 
     def mask_topography(srtm_mask, num_tokens_to_mask, mask_ratio):
         should_flip = random() < mask_ratio
@@ -89,7 +89,7 @@ def make_mask_no_dw(strategy: str, mask_ratio: float, existing_mask: np.ndarray)
         band_groups.remove(SRTM_INDEX)
         band_groups_to_mask = sample(band_groups, num_band_groups_to_mask)
         for band_group in band_groups_to_mask:
-            num_tokens_masked += len(mask[:, band_group]) - sum(mask[:, band_group])
+            num_tokens_masked += int(len(mask[:, band_group]) - sum(mask[:, band_group]))
             mask[:, band_group] = True
         num_tokens_to_mask += num_tokens_masked
         mask = random_masking(mask, num_tokens_to_mask)
@@ -101,7 +101,7 @@ def make_mask_no_dw(strategy: str, mask_ratio: float, existing_mask: np.ndarray)
         timesteps_to_mask = int(num_tokens_to_mask / (len(BANDS_GROUPS_IDX) - 1))
         max_tokens_masked = (len(BANDS_GROUPS_IDX) - 1) * timesteps_to_mask
         timesteps = sample(TIMESTEPS_IDX, k=timesteps_to_mask)
-        num_tokens_to_mask -= max_tokens_masked - sum(sum(mask[timesteps]))
+        num_tokens_to_mask -= int(max_tokens_masked - sum(sum(mask[timesteps])))
         mask[timesteps] = True
         mask = random_masking(mask, num_tokens_to_mask)
     elif strategy == "chunk_timesteps":
@@ -110,8 +110,8 @@ def make_mask_no_dw(strategy: str, mask_ratio: float, existing_mask: np.ndarray)
         timesteps_to_mask = int(num_tokens_to_mask / (len(BANDS_GROUPS_IDX) - 1))
         max_tokens_masked = (len(BANDS_GROUPS_IDX) - 1) * timesteps_to_mask
         start_idx = randint(0, NUM_TIMESTEPS - timesteps_to_mask)
-        num_tokens_to_mask -= max_tokens_masked - sum(
-            sum(mask[start_idx : start_idx + timesteps_to_mask])
+        num_tokens_to_mask -= int(
+            max_tokens_masked - sum(sum(mask[start_idx : start_idx + timesteps_to_mask]))
         )
         mask[start_idx : start_idx + timesteps_to_mask] = True  # noqa
         mask = random_masking(mask, num_tokens_to_mask)

--- a/src/presto.py
+++ b/src/presto.py
@@ -472,7 +472,10 @@ class Encoder(nn.Module):
 
         # mask will be a boolean of shape [batch, total_num_tokens]
         if eval_task:
-            return self.norm(x.mean(dim=1))
+            # set masked tokens to 0
+            x_for_mean = x * (1 - upd_mask.unsqueeze(-1))
+            x_mean = x_for_mean.sum(dim=1) / torch.sum(1 - upd_mask, -1, keepdim=True)
+            return self.norm(x_mean)
         return self.norm(x), orig_indices, upd_mask
 
 

--- a/src/presto.py
+++ b/src/presto.py
@@ -379,7 +379,7 @@ class Encoder(nn.Module):
         # cut off to the length of the longest sequence
         max_length = sorted_mask.sum(-1).max()
         x = x[:, :max_length]
-        updated_mask = (1 - sorted_mask[:, :max_length]).int()
+        updated_mask = 1 - sorted_mask[:, :max_length]
 
         return x, indices, updated_mask
 
@@ -395,7 +395,7 @@ class Encoder(nn.Module):
         device = x.device
 
         if mask is None:
-            mask = torch.zeros_like(x, device=x.device).bool()
+            mask = torch.zeros_like(x, device=x.device)
 
         months = month_to_tensor(month, x.shape[0], x.shape[1], device)
         month_embedding = self.month_embed(months)
@@ -460,14 +460,9 @@ class Encoder(nn.Module):
         # append latlon tokens
         latlon_tokens = self.latlon_embed(self.cartesian(latlons)).unsqueeze(1)
         x = torch.cat((latlon_tokens, x), dim=1)
-        upd_mask = torch.cat(
-            (torch.zeros(x.shape[0], dtype=torch.int)[:, None].to(device), upd_mask), dim=1
-        )
+        upd_mask = torch.cat((torch.zeros(x.shape[0])[:, None].to(device), upd_mask), dim=1)
         orig_indices = torch.cat(
-            (
-                torch.zeros(x.shape[0], dtype=torch.int)[:, None].to(device),
-                orig_indices + 1,
-            ),
+            (torch.zeros(x.shape[0])[:, None].to(device).int(), orig_indices + 1),
             dim=1,
         )
 
@@ -566,7 +561,7 @@ class Decoder(nn.Module):
         mask = torch.cat(
             (
                 x_mask,
-                torch.ones((x.shape[0], orig_indices.shape[1] - x.shape[1]), device=device).int(),
+                torch.ones((x.shape[0], orig_indices.shape[1] - x.shape[1]), device=device),
             ),
             dim=-1,
         )

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,9 +1,12 @@
 from unittest import TestCase
 
 import numpy as np
+import pandas as pd
 
 from src.dataops import NUM_ORG_BANDS, NUM_TIMESTEPS
-from src.dataset import WorldCerealLabelledDataset
+from src.dataset import WorldCerealLabelledDataset, WorldCerealMaskedDataset
+from src.masking import MaskParamsNoDw
+from src.utils import data_dir
 
 
 class TestUtils(TestCase):
@@ -12,3 +15,31 @@ class TestUtils(TestCase):
         test_data[0, 0] = WorldCerealLabelledDataset._NODATAVALUE
         out = WorldCerealLabelledDataset.normalize_and_mask(test_data)
         self.assertEqual(out[0, 0], 0)
+
+    def test_output(self):
+        MISSING_DATA_ROW = 86268
+        df = pd.read_parquet(data_dir / "worldcereal_testdf.parquet")
+        location_index = df.index.get_loc(MISSING_DATA_ROW)
+        strategies = [
+            "group_bands",
+            "random_timesteps",
+            "chunk_timesteps",
+            "random_combinations",
+        ]
+        ds = WorldCerealMaskedDataset(df, MaskParamsNoDw(strategies, 0.8))
+        vals = ds[location_index]
+        mask = vals[0]
+        eo_data = vals[2]
+        y = vals[3]
+        true_mask = vals[9]
+        self.assertTrue((mask[true_mask] == True).all())
+        self.assertTrue((eo_data[true_mask] == 0).all())
+        # we are very confident these should not be 0 after normalization
+        combined_s2_s1 = (eo_data + y)[:, :-5]
+        combined_s2_s1_mask = true_mask[:, :-5]
+        self.assertTrue((combined_s2_s1[~combined_s2_s1_mask] != 0).all())
+
+        # finally, check the masking we do in train.py works as expected
+        mask[true_mask] = False
+        s1_s2_mask = mask[:, :-5]
+        self.assertTrue((y[:, :-5][s1_s2_mask] != 0).all())

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -1,0 +1,112 @@
+from unittest import TestCase
+
+import numpy as np
+
+from src.masking import BANDS_GROUPS_IDX, NUM_TIMESTEPS, make_mask_no_dw
+
+TEST_MASK_RATIOS = [x / 100 for x in range(5, 100, 5)]
+
+
+class TestMasking(TestCase):
+    def test_make_mask_group_bands(self):
+        for mask_ratio in TEST_MASK_RATIOS:
+            real_masked_tokens = np.zeros((NUM_TIMESTEPS, len(BANDS_GROUPS_IDX))).astype(bool)
+            real_masked_tokens[0, 0] = True
+            eo_mask = make_mask_no_dw(
+                strategy="group_bands", mask_ratio=mask_ratio, existing_mask=real_masked_tokens
+            )
+
+            num_masked_channels = 0
+            num_masked_tokens = 0
+            srtm_masked = False
+            for channel, indices in BANDS_GROUPS_IDX.items():
+                channel_vals = eo_mask[:, indices]
+                if channel == "SRTM":
+                    self.assertTrue(channel_vals.max() == channel_vals.min())
+                    if channel_vals.max() == 1:
+                        num_masked_tokens += 1
+                        srtm_masked = True
+                else:
+                    for timestep in range(channel_vals.shape[0]):
+                        # within a token, all timestep should be correctly masked
+                        self.assertTrue(
+                            channel_vals[timestep].max() == channel_vals[timestep].min()
+                        )
+                        num_masked_tokens += channel_vals[timestep].max()
+                    if channel_vals.max() == channel_vals.min() == 1:
+                        num_masked_channels += 1
+
+            expected_masked_tokens = int(
+                ((NUM_TIMESTEPS * (len(BANDS_GROUPS_IDX) - 1)) + 1) * mask_ratio
+            )
+            self.assertTrue(
+                num_masked_tokens == expected_masked_tokens,
+                f"Expected {expected_masked_tokens} masked tokens, "
+                f"got {num_masked_tokens} for ratio {mask_ratio}",
+            )
+            if srtm_masked:
+                expected_masked_tokens -= 1
+            self.assertTrue(
+                num_masked_channels == int((expected_masked_tokens - 1) / NUM_TIMESTEPS)
+            )
+
+    def test_make_mask_timesteps(self):
+
+        for mask_ratio in TEST_MASK_RATIOS:
+            for masking_strategy in ["random_timesteps", "chunk_timesteps"]:
+                real_masked_tokens = np.zeros((NUM_TIMESTEPS, len(BANDS_GROUPS_IDX))).astype(bool)
+                real_masked_tokens[0, 0] = True
+                eo_mask = make_mask_no_dw(
+                    strategy=masking_strategy,
+                    mask_ratio=mask_ratio,
+                    existing_mask=real_masked_tokens,
+                )
+
+                num_masked_timesteps = 0
+                num_masked_tokens = 0
+                srtm_masked = False
+
+                channel_vals = eo_mask[:, BANDS_GROUPS_IDX["SRTM"]]
+                self.assertTrue(channel_vals.max() == channel_vals.min())
+                if channel_vals.max() == 1:
+                    num_masked_tokens += 1
+                    srtm_masked = True
+
+                total_mask = eo_mask[
+                    :, [x for x in range(eo_mask.shape[1]) if x not in BANDS_GROUPS_IDX["SRTM"]]
+                ]
+                for timestep in range(total_mask.shape[0]):
+
+                    timestep_vals = total_mask[timestep, :]
+                    if timestep_vals.max() == timestep_vals.min() == 1:
+                        num_masked_timesteps += 1
+
+                for channel, indices in BANDS_GROUPS_IDX.items():
+                    channel_vals = eo_mask[:, indices]
+                    if channel == "SRTM":
+                        continue  # already tested
+                    else:
+                        for timestep in range(channel_vals.shape[0]):
+                            # within a token, all timestep should be correctly masked
+                            self.assertTrue(
+                                channel_vals[timestep].max() == channel_vals[timestep].min()
+                            )
+                            num_masked_tokens += channel_vals[timestep].max()
+
+            expected_masked_tokens = int(
+                ((NUM_TIMESTEPS * (len(BANDS_GROUPS_IDX) - 1)) + 1) * mask_ratio
+            )
+            self.assertTrue(
+                num_masked_tokens == expected_masked_tokens,
+                f"Expected {expected_masked_tokens} masked tokens, "
+                f"got {num_masked_tokens} for ratio {mask_ratio}",
+            )
+            if srtm_masked:
+                expected_masked_tokens -= 1
+            self.assertTrue(
+                num_masked_timesteps
+                == int((expected_masked_tokens - 1) / (len(BANDS_GROUPS_IDX) - 1)),
+                f"Expected {num_masked_timesteps} masked timesteps, got "
+                f"{int((expected_masked_tokens - 1) / (len(BANDS_GROUPS_IDX) - 1))} "
+                f"for ratio {mask_ratio}",
+            )

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -9,11 +9,14 @@ TEST_MASK_RATIOS = [x / 100 for x in range(5, 100, 5)]
 
 class TestMasking(TestCase):
     def test_make_mask_group_bands(self):
+        real_masked_tokens = np.zeros((NUM_TIMESTEPS, len(BANDS_GROUPS_IDX))).astype(bool)
+        real_masked_tokens[0, 0] = True
         for mask_ratio in TEST_MASK_RATIOS:
-            real_masked_tokens = np.zeros((NUM_TIMESTEPS, len(BANDS_GROUPS_IDX))).astype(bool)
-            real_masked_tokens[0, 0] = True
             eo_mask = make_mask_no_dw(
                 strategy="group_bands", mask_ratio=mask_ratio, existing_mask=real_masked_tokens
+            )
+            self.assertTrue(
+                (eo_mask[0, BANDS_GROUPS_IDX[list(BANDS_GROUPS_IDX.keys())[0]]] == 1).all()
             )
 
             num_masked_channels = 0
@@ -51,15 +54,18 @@ class TestMasking(TestCase):
             )
 
     def test_make_mask_timesteps(self):
-
+        real_masked_tokens = np.zeros((NUM_TIMESTEPS, len(BANDS_GROUPS_IDX))).astype(bool)
+        real_masked_tokens[0, 0] = True
         for mask_ratio in TEST_MASK_RATIOS:
             for masking_strategy in ["random_timesteps", "chunk_timesteps"]:
-                real_masked_tokens = np.zeros((NUM_TIMESTEPS, len(BANDS_GROUPS_IDX))).astype(bool)
-                real_masked_tokens[0, 0] = True
+
                 eo_mask = make_mask_no_dw(
                     strategy=masking_strategy,
                     mask_ratio=mask_ratio,
                     existing_mask=real_masked_tokens,
+                )
+                self.assertTrue(
+                    (eo_mask[0, BANDS_GROUPS_IDX[list(BANDS_GROUPS_IDX.keys())[0]]] == 1).all()
                 )
 
                 num_masked_timesteps = 0

--- a/tests/test_presto.py
+++ b/tests/test_presto.py
@@ -24,7 +24,7 @@ class TestPresto(TestCase):
     def test_encoder_init(self):
         batch_size = 3
         input = S1_S2_ERA5_SRTM.normalize(torch.zeros((batch_size, NUM_TIMESTEPS, NUM_ORG_BANDS)))
-        input_mask = torch.zeros_like(input, dtype=torch.int)
+        input_mask = torch.zeros_like(input)
         dynamic_world = torch.ones((batch_size, NUM_TIMESTEPS)).long()
         latlons = torch.rand((batch_size, 2))
         model = Encoder()
@@ -74,7 +74,7 @@ class TestPresto(TestCase):
     def test_end_to_end(self):
         batch_size = 3
         input = S1_S2_ERA5_SRTM.normalize(torch.zeros((batch_size, NUM_TIMESTEPS, NUM_ORG_BANDS)))
-        input_mask = torch.zeros_like(input, dtype=torch.int)
+        input_mask = torch.zeros_like(input)
         dynamic_world = torch.ones((batch_size, NUM_TIMESTEPS)).long()
         latlons = torch.rand((batch_size, 2))
 
@@ -92,7 +92,7 @@ class TestPresto(TestCase):
 
     def test_tokens_correctly_masked(self):
         x = torch.tensor([[1, 2, 3, 4, 5], [1, 2, 3, 4, 5]])
-        mask = torch.zeros_like(x, dtype=torch.int)
+        mask = torch.zeros_like(x)
         x = repeat(x, "b t -> b t d", d=3).clone()
         x += torch.arange(3)[None, None]
 
@@ -115,7 +115,7 @@ class TestPresto(TestCase):
 
     def test_tokens_correctly_masked_unequal(self):
         x = torch.tensor([[1, 2, 3, 4, 5], [1, 2, 3, 4, 5]])
-        mask = torch.zeros_like(x, dtype=torch.int)
+        mask = torch.zeros_like(x)
         x = repeat(x, "b t -> b t d", d=3)
 
         mask[0, 1] = 1
@@ -146,7 +146,7 @@ class TestPresto(TestCase):
         )
         # the mask token is initialized to 0s
         orig_indices = torch.tensor([[0, 2, 3, 5, 1, 4], [0, 1, 3, 2, 4, 5]])
-        x_mask = torch.zeros((2, 4), dtype=torch.int)
+        x_mask = torch.zeros((2, 4))
 
         filled_tokens = decoder.add_masked_tokens(masked_x, orig_indices, x_mask)
 
@@ -169,7 +169,7 @@ class TestPresto(TestCase):
         )
         # the mask token is initialized to 0s
         orig_indices = torch.tensor([[0, 2, 3, 5, 1, 4], [0, 1, 3, 2, 4, 5]])
-        x_mask = torch.zeros((2, 4), dtype=torch.int)
+        x_mask = torch.zeros((2, 4))
         x_mask[0, -1] = 1
 
         filled_tokens = decoder.add_masked_tokens(masked_x, orig_indices, x_mask)
@@ -412,14 +412,9 @@ class TestPresto(TestCase):
             # append latlon tokens
             latlon_tokens = torch.ones((x.shape[0], 1, embedding_size)) * -1
             x = torch.cat((latlon_tokens, x), dim=1)
-            upd_mask = torch.cat(
-                (torch.zeros(x.shape[0], dtype=torch.int)[:, None].to(device), upd_mask), dim=1
-            )
+            upd_mask = torch.cat((torch.zeros(x.shape[0])[:, None].to(device), upd_mask), dim=1)
             orig_indices = torch.cat(
-                (
-                    torch.zeros(upd_mask.shape[0], dtype=torch.int)[:, None].to(device),
-                    orig_indices + 1,
-                ),
+                (torch.zeros(upd_mask.shape[0])[:, None].to(device).int(), orig_indices + 1),
                 dim=1,
             )
 
@@ -435,7 +430,7 @@ class TestPresto(TestCase):
 
         dw_value = -2
         dynamic_world = torch.ones((batch_size, timesteps)) * dw_value
-        mask = torch.zeros_like(x, dtype=torch.int)
+        mask = torch.zeros_like(x)
 
         eo, dw = forward(x, dynamic_world, mask, model)
         for group, idxs in BANDS_GROUPS_IDX.items():

--- a/train.py
+++ b/train.py
@@ -201,7 +201,7 @@ with tqdm(range(num_epochs), desc="Epoch") as tqdm_epoch:
         for epoch_step, b in enumerate(tqdm(train_dataloader, desc="Train", leave=False)):
             mask, x, y, start_month = b[0].to(device), b[2].to(device), b[3].to(device), b[6]
             dw_mask, x_dw, y_dw = b[1].to(device), b[4].to(device).long(), b[5].to(device).long()
-            latlons, real_mask = b[7].to(device), b[8].to(device)
+            latlons, real_mask = b[7].to(device), b[9].to(device)
             # zero the parameter gradients
             optimizer.zero_grad()
             lr = adjust_learning_rate(
@@ -245,7 +245,7 @@ with tqdm(range(num_epochs), desc="Epoch") as tqdm_epoch:
                             b[2].to(device),
                             b[3].to(device),
                             b[6],
-                            b[8].to(device),
+                            b[9].to(device),
                         )
                         dw_mask, x_dw = b[1].to(device), b[4].to(device).long()
                         y_dw, latlons = b[5].to(device).long(), b[7].to(device)


### PR DESCRIPTION
- [x] Update masking function to consider a "real" mask as well
- [x] Update train script to mask out "real" mask in loss
- [x] Update eval tasks to use the masking too ~~(will likely require a batch size of 1, which could really slow things down). In the future implement masking within the model's attention mechanism.~~ I do sub-batches per unique number of masked tokens in a batch, which I think is a good trade-off.

Closes #1 