### PR TITLE
Update code to work with datasets shared in #34

### DIFF
--- a/presto/dataset.py
+++ b/presto/dataset.py
@@ -116,7 +116,7 @@ class WorldCerealBase(Dataset):
 
     @staticmethod
     def split_df(
-        df: pd.DataFrame, val_sample_ids: List[str] = None, val_size: float = 0.2
+        df: pd.DataFrame, val_sample_ids: Optional[List[str]] = None, val_size: float = 0.2
     ) -> Tuple[pd.DataFrame, pd.DataFrame]:
         if val_sample_ids is None:
             logger.warning(f"No val_ids; randomly splitting {val_size} to the val set instead")

--- a/presto/dataset.py
+++ b/presto/dataset.py
@@ -18,7 +18,7 @@ from .dataops import (
     DynamicWorld2020_2021,
 )
 from .masking import BAND_EXPANSION, MaskedExample, MaskParamsNoDw
-from .utils import data_dir
+from .utils import DEFAULT_SEED, data_dir
 
 IDX_TO_BAND_GROUPS = {}
 for band_group_idx, (key, val) in enumerate(BANDS_GROUPS_IDX.items()):
@@ -104,6 +104,13 @@ class WorldCerealBase(Dataset):
     def check(array: np.ndarray) -> np.ndarray:
         assert not np.isnan(array).any()
         return array
+
+    @staticmethod
+    def split_df(df: pd.DataFrame, val_size: float = 0.2) -> Tuple[pd.DataFrame, pd.DataFrame]:
+        val, train = np.split(
+            df.sample(frac=1, random_state=DEFAULT_SEED), [int(val_size * len(df))]
+        )
+        return train, val
 
 
 class WorldCerealMaskedDataset(WorldCerealBase):

--- a/presto/dataset.py
+++ b/presto/dataset.py
@@ -86,6 +86,8 @@ class WorldCerealBase(Dataset):
             mask[:, IDX_TO_BAND_GROUPS[presto_val]] += ~idx_valid
             eo_data[:, BANDS.index(presto_val)] = values
         for df_val, presto_val in cls.STATIC_BAND_MAPPING.items():
+            # this occurs for the DEM values in one point in Fiji
+            values = np.nan_to_num(values, nan=cls._NODATAVALUE)
             eo_data[:, BANDS.index(presto_val)] = row_d[df_val]
 
         return cls.check(eo_data), mask.astype(bool), latlon, month, row_d["LANDCOVER_LABEL"] == 11

--- a/presto/dataset.py
+++ b/presto/dataset.py
@@ -71,7 +71,7 @@ class WorldCerealBase(Dataset):
         for df_val, presto_val in cls.BAND_MAPPING.items():
             values = np.array([float(row_d[df_val.format(t)]) for t in range(cls.NUM_TIMESTEPS)])
             # this occurs for the DEM values in one point in Fiji
-            values[np.isnan(values)] = cls._NODATAVALUE
+            values = np.nan_to_num(values, nan=cls._NODATAVALUE)
             idx_valid = values != cls._NODATAVALUE
             if presto_val in ["VV", "VH"]:
                 # convert to dB

--- a/presto/dataset.py
+++ b/presto/dataset.py
@@ -70,6 +70,8 @@ class WorldCerealBase(Dataset):
         mask = np.zeros((cls.NUM_TIMESTEPS, len(BANDS_GROUPS_IDX)))
         for df_val, presto_val in cls.BAND_MAPPING.items():
             values = np.array([float(row_d[df_val.format(t)]) for t in range(cls.NUM_TIMESTEPS)])
+            # this occurs for the DEM values in one point in Fiji
+            values[np.isnan(values)] = cls._NODATAVALUE
             idx_valid = values != cls._NODATAVALUE
             if presto_val in ["VV", "VH"]:
                 # convert to dB

--- a/presto/dataset.py
+++ b/presto/dataset.py
@@ -87,8 +87,10 @@ class WorldCerealBase(Dataset):
             eo_data[:, BANDS.index(presto_val)] = values
         for df_val, presto_val in cls.STATIC_BAND_MAPPING.items():
             # this occurs for the DEM values in one point in Fiji
-            values = np.nan_to_num(values, nan=cls._NODATAVALUE)
-            eo_data[:, BANDS.index(presto_val)] = row_d[df_val]
+            values = np.nan_to_num(row_d[df_val], nan=cls._NODATAVALUE)
+            idx_valid = values != cls._NODATAVALUE
+            eo_data[:, BANDS.index(presto_val)] = values
+            mask[:, IDX_TO_BAND_GROUPS[presto_val]] += ~idx_valid
 
         return cls.check(eo_data), mask.astype(bool), latlon, month, row_d["LANDCOVER_LABEL"] == 11
 

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -235,10 +235,7 @@ class WorldCerealEval:
         test_preds_np = test_preds_np >= self.threshold
         prefix = f"{self.name}_{finetuned_model.__class__.__name__}"
 
-        test_df = self.test_df.loc[
-            ~self.test_df.LANDCOVER_LABEL.isin(WorldCerealLabelledDataset.FILTER_LABELS)
-        ]
-        catboost_preds = test_df.worldcereal_prediction
+        catboost_preds = test_ds.df.worldcereal_prediction
 
         def format_partitioned(results):
             return {
@@ -253,7 +250,7 @@ class WorldCerealEval:
             f"{self.name}_CatBoost_f1": float(f1_score(target_np, catboost_preds)),
             f"{self.name}_CatBoost_recall": float(recall_score(target_np, catboost_preds)),
             f"{self.name}_CatBoost_precision": float(precision_score(target_np, catboost_preds)),
-            **format_partitioned(self.partitioned_metrics(target_np, test_preds_np)),
+            **format_partitioned(self.partitioned_metrics(target_np, test_preds_np, test_ds.df)),
         }
 
     @staticmethod
@@ -291,11 +288,11 @@ class WorldCerealEval:
         return res
 
     def partitioned_metrics(
-        self, target: np.ndarray, preds: np.ndarray
+        self,
+        target: np.ndarray,
+        preds: np.ndarray,
+        test_df: pd.DataFrame,
     ) -> Dict[str, Union[np.float32, np.int32]]:
-        test_df = self.test_df.loc[
-            ~self.test_df.LANDCOVER_LABEL.isin(WorldCerealLabelledDataset.FILTER_LABELS)
-        ]
         catboost_preds = test_df.worldcereal_prediction
         years = test_df.end_date.apply(lambda date: date[:4])
 

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -210,10 +210,11 @@ class WorldCerealEval:
             )
             test_preds_np, _ = self._inference_for_dl(dl, finetuned_model, pretrained_model)
             df = ds.combine_predictions(latlons, test_preds_np, y)
+            prefix = f"{self.name}_{ds.all_files[i].stem}"
             if pretrained_model is None:
-                filename = f"{ds.all_files[i].stem}_finetuning.nc"
+                filename = f"{prefix}_finetuning.nc"
             else:
-                filename = f"{ds.all_files[i].stem}_{finetuned_model.__class__.__name__}.nc"
+                filename = f"{prefix}_{finetuned_model.__class__.__name__}.nc"
             df.to_xarray().to_netcdf(self.spatial_inference_savedir / filename)
 
     @torch.no_grad()

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -297,7 +297,9 @@ class WorldCerealEval:
         years = test_df.end_date.apply(lambda date: date[:4])
 
         latlons = gpd.GeoDataFrame(
-            geometry=gpd.GeoSeries.from_xy(x=test_df.lon, y=test_df.lat), crs="EPSG:4326"
+            data={"year": test_df.year},
+            geometry=gpd.GeoSeries.from_xy(x=test_df.lon, y=test_df.lat),
+            crs="EPSG:4326",
         )
         # project to non geographic CRS, otherwise geopandas gives a warning
         world_attrs = gpd.sjoin_nearest(

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -238,7 +238,7 @@ class WorldCerealEval:
         test_df = self.test_df.loc[
             ~self.test_df.LANDCOVER_LABEL.isin(WorldCerealLabelledDataset.FILTER_LABELS)
         ]
-        catboost_preds = test_df.catboost_prediction
+        catboost_preds = test_df.worldcereal_prediction
 
         def format_partitioned(results):
             return {

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -62,7 +62,7 @@ class WorldCerealEval:
         cols = [f"SAR-{s}-ts{t}-20m" for s in ["VV", "VH"] for t in range(12)]
         self.train_df = train_data[~(train_data.loc[:, cols] == 0.0).any(axis=1)]
 
-        self.val_df = val_data.drop_duplicates(subset=["pixelids", "lat", "lon", "end_date"])
+        self.val_df = val_data.drop_duplicates(subset=["sample_id", "lat", "lon", "end_date"])
         self.val_df = self.val_df[~pd.isna(self.val_df).any(axis=1)]
         self.val_df = self.val_df[~(self.val_df.loc[:, cols] == 0.0).any(axis=1)]
         self.test_df = self.val_df

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -296,7 +296,7 @@ class WorldCerealEval:
         test_df = self.test_df.loc[
             ~self.test_df.LANDCOVER_LABEL.isin(WorldCerealLabelledDataset.FILTER_LABELS)
         ]
-        catboost_preds = test_df.catboost_prediction
+        catboost_preds = test_df.worldcereal_prediction
         years = test_df.end_date.apply(lambda date: date[:4])
 
         latlons = gpd.GeoDataFrame(

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -65,6 +65,7 @@ class WorldCerealEval:
         self.val_df = val_data.drop_duplicates(subset=["sample_id", "lat", "lon", "end_date"])
         self.val_df = self.val_df[~pd.isna(self.val_df).any(axis=1)]
         self.val_df = self.val_df[~(self.val_df.loc[:, cols] == 0.0).any(axis=1)]
+        self.val_df = self.val_df.set_index("sample_id")
         self.test_df = self.val_df
 
         self.world_df = gpd.read_file(utils.data_dir / world_shp_path)

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -297,7 +297,6 @@ class WorldCerealEval:
         years = test_df.end_date.apply(lambda date: date[:4])
 
         latlons = gpd.GeoDataFrame(
-            data={"year": test_df.year},
             geometry=gpd.GeoSeries.from_xy(x=test_df.lon, y=test_df.lat),
             crs="EPSG:4326",
         )

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -25,6 +25,10 @@ class TestDataset(TestCase):
     def test_output(self):
         MISSING_DATA_ROW = 0
         df = pd.read_parquet(data_dir / "worldcereal_testdf.parquet")
+        # this is to align the parquet file with the new parquet files
+        # shared in https://github.com/WorldCereal/presto-worldcereal/pull/34
+        df.rename({"catboost_predictions": "worldcereal_predictions"}, axis=1, inplace=True)
+
         location_index = df.index.get_loc(MISSING_DATA_ROW)
         strategies = [
             "group_bands",

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -27,7 +27,7 @@ class TestDataset(TestCase):
         df = pd.read_parquet(data_dir / "worldcereal_testdf.parquet")
         # this is to align the parquet file with the new parquet files
         # shared in https://github.com/WorldCereal/presto-worldcereal/pull/34
-        df.rename({"catboost_predictions": "worldcereal_predictions"}, axis=1, inplace=True)
+        df.rename({"catboost_prediction": "worldcereal_prediction"}, axis=1, inplace=True)
 
         location_index = df.index.get_loc(MISSING_DATA_ROW)
         strategies = [

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -17,6 +17,9 @@ class TestEval(TestCase):
         model = Presto.load_pretrained()
 
         test_data = pd.read_parquet(data_dir / "worldcereal_testdf.parquet")[:20]
+        # this is to align the parquet file with the new parquet files
+        # shared in https://github.com/WorldCereal/presto-worldcereal/pull/34
+        test_data.rename({"pixelids": "sample_id"}, axis=1, inplace=True)
         labels = [99] * len(test_data)  # 99 = No cropland
         labels[:10] = [11] * 10  # 11 = Annual cropland
         test_data["LANDCOVER_LABEL"] = labels
@@ -34,6 +37,9 @@ class TestEval(TestCase):
         model = Presto.load_pretrained()
 
         test_data = pd.read_parquet(data_dir / "worldcereal_testdf.parquet")[:20]
+        # this is to align the parquet file with the new parquet files
+        # shared in https://github.com/WorldCereal/presto-worldcereal/pull/34
+        test_data.rename({"pixelids": "sample_id"}, axis=1, inplace=True)
         labels = [99] * len(test_data)  # 99 = No cropland
         labels[:10] = [11] * 10  # 11 = Annual cropland
         test_data["LANDCOVER_LABEL"] = labels

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -20,7 +20,7 @@ class TestEval(TestCase):
         # this is to align the parquet file with the new parquet files
         # shared in https://github.com/WorldCereal/presto-worldcereal/pull/34
         test_data.rename(
-            {"pixelids": "sample_id", "catboost_predictions": "worldcereal_predictions"},
+            {"pixelids": "sample_id", "catboost_prediction": "worldcereal_prediction"},
             axis=1,
             inplace=True,
         )
@@ -44,7 +44,7 @@ class TestEval(TestCase):
         # this is to align the parquet file with the new parquet files
         # shared in https://github.com/WorldCereal/presto-worldcereal/pull/34
         test_data.rename(
-            {"pixelids": "sample_id", "catboost_predictions": "worldcereal_predictions"},
+            {"pixelids": "sample_id", "catboost_prediction": "worldcereal_prediction"},
             axis=1,
             inplace=True,
         )

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -60,7 +60,9 @@ class TestEval(TestCase):
             )
             finetuned_model = eval_task._construct_finetuning_model(model)
             eval_task.spatial_inference(finetuned_model, None)
-            output = xr.open_dataset(Path(tmpdirname) / f"{spatial_data_prefix}_finetuning.nc")
+            output = xr.open_dataset(
+                Path(tmpdirname) / f"{eval_task.name}_{spatial_data_prefix}_finetuning.nc"
+            )
             # np.flip because of how lat lons are stored vs x y
             self.assertTrue(
                 np.equal(np.flip(output.ground_truth.values, 0), ground_truth_one_timestep).all()

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -19,10 +19,11 @@ class TestEval(TestCase):
         # this is to align the parquet file with the new parquet files
         # shared in https://github.com/WorldCereal/presto-worldcereal/pull/34
         test_df.rename(
-            {"pixelids": "sample_id", "catboost_prediction": "worldcereal_prediction"},
+            {"catboost_prediction": "worldcereal_prediction"},
             axis=1,
             inplace=True,
         )
+        test_df["sample_id"] = np.arange(len(test_df))
         test_df["year"] = 2021
         labels = [99] * len(test_df)  # 99 = No cropland
         labels[:10] = [11] * 10  # 11 = Annual cropland

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -13,7 +13,6 @@ from presto.utils import data_dir
 
 
 class TestEval(TestCase):
-
     @staticmethod
     def read_test_file() -> pd.DataFrame:
         test_df = pd.read_parquet(data_dir / "worldcereal_testdf.parquet")[:20]

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -19,7 +19,11 @@ class TestEval(TestCase):
         test_data = pd.read_parquet(data_dir / "worldcereal_testdf.parquet")[:20]
         # this is to align the parquet file with the new parquet files
         # shared in https://github.com/WorldCereal/presto-worldcereal/pull/34
-        test_data.rename({"pixelids": "sample_id"}, axis=1, inplace=True)
+        test_data.rename(
+            {"pixelids": "sample_id", "catboost_predictions": "worldcereal_predictions"},
+            axis=1,
+            inplace=True,
+        )
         labels = [99] * len(test_data)  # 99 = No cropland
         labels[:10] = [11] * 10  # 11 = Annual cropland
         test_data["LANDCOVER_LABEL"] = labels
@@ -39,7 +43,11 @@ class TestEval(TestCase):
         test_data = pd.read_parquet(data_dir / "worldcereal_testdf.parquet")[:20]
         # this is to align the parquet file with the new parquet files
         # shared in https://github.com/WorldCereal/presto-worldcereal/pull/34
-        test_data.rename({"pixelids": "sample_id"}, axis=1, inplace=True)
+        test_data.rename(
+            {"pixelids": "sample_id", "catboost_predictions": "worldcereal_predictions"},
+            axis=1,
+            inplace=True,
+        )
         labels = [99] * len(test_data)  # 99 = No cropland
         labels[:10] = [11] * 10  # 11 = Annual cropland
         test_data["LANDCOVER_LABEL"] = labels

--- a/train.py
+++ b/train.py
@@ -74,6 +74,7 @@ argparser.add_argument("--num_workers", type=int, default=4)
 argparser.add_argument("--wandb", dest="wandb", action="store_true")
 argparser.add_argument("--wandb_org", type=str, default="nasa-harvest")
 argparser.add_argument("--parquet_file", type=str, default="rawts-monthly_calval.parquet")
+argparser.add_argument("--val_samples_file", type=str, default="VAL_samples.csv")
 argparser.add_argument("--warm_start", dest="warm_start", action="store_true")
 argparser.set_defaults(wandb=False)
 argparser.set_defaults(warm_start=True)
@@ -121,6 +122,7 @@ if (len(mask_strategies) == 1) and (mask_strategies[0] == "all"):
 mask_ratio: float = args["mask_ratio"]
 
 parquet_file: str = args["parquet_file"]
+val_samples_file: str = args["val_samples_file"]
 
 path_to_config = config_dir / "default.json"
 model_kwargs = json.load(Path(path_to_config).open("r"))
@@ -131,7 +133,12 @@ logger.info("Setting up dataloaders")
 mask_params = MaskParamsNoDw(mask_strategies, mask_ratio)
 
 df = pd.read_parquet(data_dir / parquet_file)
-train_df, val_df = WorldCerealDataset.split_df(df)
+if (data_dir / val_samples_file).exists():
+    val_samples_df = pd.read_csv(data_dir / val_samples_file)
+    val_samples = val_samples_df.tolist()
+    train_df, val_df = WorldCerealDataset.split_df(df, val_sample_ids=val_samples)
+else:
+    train_df, val_df = WorldCerealDataset.split_df(df)
 train_dataloader = DataLoader(
     WorldCerealDataset(train_df, mask_params=mask_params),
     batch_size=batch_size,

--- a/train.py
+++ b/train.py
@@ -135,7 +135,7 @@ mask_params = MaskParamsNoDw(mask_strategies, mask_ratio)
 df = pd.read_parquet(data_dir / parquet_file)
 if (data_dir / val_samples_file).exists():
     val_samples_df = pd.read_csv(data_dir / val_samples_file)
-    val_samples = val_samples_df.tolist()
+    val_samples = val_samples_df.sample_id.tolist()
     train_df, val_df = WorldCerealDataset.split_df(df, val_sample_ids=val_samples)
 else:
     train_df, val_df = WorldCerealDataset.split_df(df)

--- a/train.py
+++ b/train.py
@@ -73,16 +73,7 @@ argparser.add_argument("--seed", type=int, default=DEFAULT_SEED)
 argparser.add_argument("--num_workers", type=int, default=4)
 argparser.add_argument("--wandb", dest="wandb", action="store_true")
 argparser.add_argument("--wandb_org", type=str, default="nasa-harvest")
-argparser.add_argument(
-    "--train_file",
-    type=str,
-    default="worldcereal_presto_cropland_nointerp_V1_TRAIN.parquet",
-)
-argparser.add_argument(
-    "--val_file",
-    type=str,
-    default="worldcereal_presto_cropland_nointerp_V2_VAL.parquet",
-)
+argparser.add_argument("--parquet_file", type=str, default="rawts-monthly_calval.parquet")
 argparser.add_argument("--warm_start", dest="warm_start", action="store_true")
 argparser.set_defaults(wandb=False)
 argparser.set_defaults(warm_start=True)
@@ -129,8 +120,7 @@ if (len(mask_strategies) == 1) and (mask_strategies[0] == "all"):
     mask_strategies = MASK_STRATEGIES
 mask_ratio: float = args["mask_ratio"]
 
-train_file: str = args["train_file"]
-val_file: str = args["val_file"]
+parquet_file: str = args["parquet_file"]
 
 path_to_config = config_dir / "default.json"
 model_kwargs = json.load(Path(path_to_config).open("r"))
@@ -140,8 +130,8 @@ logger.info("Setting up dataloaders")
 # Load the mask parameters
 mask_params = MaskParamsNoDw(mask_strategies, mask_ratio)
 
-train_df = pd.read_parquet(data_dir / train_file)
-val_df = pd.read_parquet(data_dir / val_file)
+df = pd.read_parquet(data_dir / parquet_file)
+train_df, val_df = WorldCerealDataset.split_df(df)
 train_dataloader = DataLoader(
     WorldCerealDataset(train_df, mask_params=mask_params),
     batch_size=batch_size,


### PR DESCRIPTION
- [x] Use the val `.txt` file to create the train val split
- [x] Update `catboost_` -> `worldcereal_`
- [x] Update `pixelids` -> `sample_id` 

Run: https://wandb.ai/nasa-harvest/presto-worldcereal/runs/zwolm9c6. Results with all the data (from this run):

| Model | F1 score | Precision | Recall |
| --- | --- | --- | --- |
| CatBoost | 0.849 | 0.846 | 0.852 |
| Presto finetuning | 0.857 | 0.813 | 0.907 |
| Presto finetuning + RF | 0.866 | 0.894 | 0.839 |
| Presto finetuning + LR | 0.859 | 0.812 | 0.911 |
| Presto finetuning + CatBoost | 0.863 | 0.822 | 0.908 |
 