### PR TITLE
Improve class weight computation + CatBoost improvements

### DIFF
--- a/presto/dataset.py
+++ b/presto/dataset.py
@@ -196,7 +196,7 @@ class WorldCerealLabelledDataset(WorldCerealBase):
         countries_to_remove: Optional[List[str]] = None,
         years_to_remove: Optional[List[int]] = None,
         target_function: Optional[Callable[[Dict], int]] = None,
-        balance: bool = True,
+        balance: bool = False,
     ):
         dataframe = dataframe.loc[~dataframe.LANDCOVER_LABEL.isin(self.FILTER_LABELS)]
 
@@ -216,12 +216,12 @@ class WorldCerealLabelledDataset(WorldCerealBase):
         super().__init__(dataframe)
         if balance:
             neg_indices, pos_indices = [], []
-            for idx, row in self.df.iterrows():
+            for loc_idx, (_, row) in enumerate(self.df.iterrows()):
                 target = self.target_function(row.to_dict())
                 if target == 0:
-                    neg_indices.append(idx)
+                    neg_indices.append(loc_idx)
                 else:
-                    pos_indices.append(idx)
+                    pos_indices.append(loc_idx)
             if len(pos_indices) > len(neg_indices):
                 self.indices = pos_indices + (len(pos_indices) // len(neg_indices)) * neg_indices
             elif len(neg_indices) > len(pos_indices):

--- a/presto/dataset.py
+++ b/presto/dataset.py
@@ -63,7 +63,7 @@ class WorldCerealBase(Dataset):
     @staticmethod
     def target_crop(row_d: Dict) -> int:
         # by default, we predict crop vs non crop
-        return row_d["LANDCOVER_LABEL"] == 11
+        return int(row_d["LANDCOVER_LABEL"] == 11)
 
     @classmethod
     def row_to_arrays(
@@ -185,7 +185,7 @@ def filter_remove_noncrops(df: pd.DataFrame) -> pd.DataFrame:
 
 def target_maize(row_d) -> int:
     # 1200 is maize
-    return row_d["CROPTYPE_LABEL"] == 1200
+    return int(row_d["CROPTYPE_LABEL"] == 1200)
 
 
 class WorldCerealLabelledDataset(WorldCerealBase):

--- a/presto/dataset.py
+++ b/presto/dataset.py
@@ -1,6 +1,8 @@
 import logging
 from datetime import datetime
+from math import modf
 from pathlib import Path
+from random import sample
 from typing import Callable, Dict, List, Optional, Tuple, cast
 
 import geopandas as gpd
@@ -230,6 +232,12 @@ class WorldCerealLabelledDataset(WorldCerealBase):
                 self.indices = neg_indices + pos_indices
         else:
             self.indices = [i for i in range(len(self.df))]
+
+    @staticmethod
+    def multiply_list_length_by_float(input_list: List, multiplier: float) -> List:
+        decimal_part, integer_part = modf(multiplier)
+        sublist = sample(input_list, k=int(len(input_list) * decimal_part))
+        return input_list * int(integer_part) + sublist
 
     def __len__(self):
         return len(self.indices)

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -353,7 +353,10 @@ class WorldCerealEval:
         )
 
         weights = torch.from_numpy(train_ds.class_weights)
-        loss_fn = nn.BCEWithLogitsLoss(pos_weight=(weights / weights[0])[1])
+        # these clamps are arbitrary, but an excessively large / small weight
+        # seems undesirable.
+        pos_weight = torch.clamp((weights / weights[0])[1], min=0.5, max=2)
+        loss_fn = nn.BCEWithLogitsLoss(pos_weight=pos_weight)
 
         generator = torch.Generator()
         generator.manual_seed(self.seed)

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -352,7 +352,9 @@ class WorldCerealEval:
             target_function=self.target_function,
         )
 
-        loss_fn = nn.CrossEntropyLoss(weight=torch.from_numpy(train_ds.class_weights).float())
+        loss_fn = nn.CrossEntropyLoss(
+            weight=torch.from_numpy(train_ds.class_weights).to(device).float()
+        )
 
         generator = torch.Generator()
         generator.manual_seed(self.seed)

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -344,7 +344,10 @@ class WorldCerealEval:
             countries_to_remove=self.countries_to_remove,
             years_to_remove=self.years_to_remove,
             target_function=self.target_function,
+            balance=True,
         )
+
+        # should the val set be balanced too?
         val_ds = WorldCerealLabelledDataset(
             self.val_df,
             countries_to_remove=self.countries_to_remove,

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -154,7 +154,6 @@ class WorldCerealEval:
             "CatBoostClassifier": CatBoostClassifier(
                 iterations=8000,
                 depth=8,
-                eval_metric="F1",
                 learning_rate=0.05,
                 early_stopping_rounds=20,
                 l2_leaf_reg=3,

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -352,11 +352,7 @@ class WorldCerealEval:
             target_function=self.target_function,
         )
 
-        weights = torch.from_numpy(train_ds.class_weights)
-        # these clamps are arbitrary, but an excessively large / small weight
-        # seems undesirable.
-        pos_weight = torch.clamp((weights / weights[0])[1], min=0.5, max=2)
-        loss_fn = nn.BCEWithLogitsLoss(pos_weight=pos_weight)
+        loss_fn = nn.BCEWithLogitsLoss()
 
         generator = torch.Generator()
         generator.manual_seed(self.seed)

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -171,8 +171,8 @@ class WorldCerealEval:
                     mask=variable_mask_f,
                     latlons=latlons_f,
                     month=month_f,
-                )[:, 1]
-                preds = torch.sigmoid(preds).cpu().numpy()
+                ).softmax(dim=1)[:, 1]
+                preds = preds.cpu().numpy()
             else:
                 cast(Presto, pretrained_model).eval()
                 encodings = (

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -352,7 +352,7 @@ class WorldCerealEval:
             target_function=self.target_function,
         )
 
-        weights = train_ds.class_weights
+        weights = torch.from_numpy(train_ds.class_weights)
         loss_fn = nn.BCEWithLogitsLoss(pos_weight=(weights / weights[0])[1])
 
         generator = torch.Generator()

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -143,6 +143,11 @@ class WorldCerealEval:
                 random_state=self.seed,
             ),
             "CatBoostClassifier": CatBoostClassifier(
+                iterations=500,
+                depth=8,
+                eval_metric="F1",
+                learning_rate=0.3,
+                l2_leaf_reg=100,
                 random_state=self.seed,
                 class_weights={"True": class_weight_dict[1], "False": class_weight_dict[0]},
             ),

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -143,7 +143,8 @@ class WorldCerealEval:
                 random_state=self.seed,
             ),
             "CatBoostClassifier": CatBoostClassifier(
-                random_state=self.seed, class_weights=class_weight_dict
+                random_state=self.seed,
+                class_weights={"True": class_weight_dict[1], "False": class_weight_dict[0]},
             ),
         }
         for model in tqdm(models, desc="Fitting sklearn models"):

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -148,6 +148,9 @@ class WorldCerealEval:
                 class_weight=class_weight_dict,
                 random_state=self.seed,
             ),
+            # Parameters emulate
+            # https://github.com/WorldCereal/wc-classification/blob/
+            # 4a9a839507d9b4f63c378b3b1d164325cbe843d6/src/worldcereal/classification/models.py#L490
             "CatBoostClassifier": CatBoostClassifier(
                 iterations=8000,
                 depth=8,

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -402,7 +402,7 @@ class WorldCerealEval:
                     latlons=latlons,
                     month=month,
                 ).softmax(dim=1)
-                loss = loss_fn(preds, y.float())
+                loss = loss_fn(preds, y.long())
                 epoch_train_loss += loss.item()
                 loss.backward()
                 optimizer.step()
@@ -423,7 +423,7 @@ class WorldCerealEval:
                         month=month,
                     ).softmax(dim=1)
                     all_preds.append(preds)
-                    all_y.append(y.float())
+                    all_y.append(y.long())
 
             val_loss.append(loss_fn(torch.cat(all_preds), torch.cat(all_y)))
             pbar.set_description(f"Train metric: {train_loss[-1]}, Val metric: {val_loss[-1]}")

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -159,7 +159,7 @@ class WorldCerealEval:
                 early_stopping_rounds=20,
                 l2_leaf_reg=3,
                 random_state=self.seed,
-                class_weights={"True": class_weight_dict[1], "False": class_weight_dict[0]},
+                class_weights=class_weight_dict,
             ),
         }
         for model in tqdm(models, desc="Fitting sklearn models"):

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -352,7 +352,7 @@ class WorldCerealEval:
             target_function=self.target_function,
         )
 
-        loss_fn = nn.CrossEntropyLoss(weight=torch.from_numpy(train_ds.class_weights))
+        loss_fn = nn.CrossEntropyLoss(weight=torch.from_numpy(train_ds.class_weights).float())
 
         generator = torch.Generator()
         generator.manual_seed(self.seed)

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -131,18 +131,19 @@ class WorldCerealEval:
 
         fit_models = []
         class_weights = cast(WorldCerealLabelledDataset, dl.dataset).class_weights
+        class_weight_dict = {idx: weight for idx, weight in enumerate(class_weights)}
         model_dict = {
             "Regression": LogisticRegression(
-                class_weight={idx: weight for idx, weight in enumerate(class_weights)},
+                class_weight=class_weight_dict,
                 max_iter=1000,
                 random_state=self.seed,
             ),
             "Random Forest": RandomForestClassifier(
-                class_weight={idx: weight for idx, weight in enumerate(class_weights)},
+                class_weight=class_weight_dict,
                 random_state=self.seed,
             ),
             "CatBoostClassifier": CatBoostClassifier(
-                random_state=self.seed, class_weights=class_weights
+                random_state=self.seed, class_weights=class_weight_dict
             ),
         }
         for model in tqdm(models, desc="Fitting sklearn models"):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -123,3 +123,8 @@ class TestDataset(TestCase):
             assert y in [0, 1]
             num_positives += y == 1
         self.assertTrue(num_positives == NUM_MAIZE_POINTS)
+
+    def test_list_correctly_resized(self):
+        input_list = [1] * 10
+        output_list = WorldCerealLabelledDataset.multiply_list_length_by_float(input_list, 2.5)
+        self.assertEqual(len(output_list), 25)


### PR DESCRIPTION
- [x] Use sklearn's `compute_class_weight` for both the sklearn models and catboost
- [x] Fix a bug in the finetuning class weight computation - use sklearn's `compute_class_weight` function here too 
- [x] Early stopping for the CatBoost classifier, and update CatBoost classifier parameters

## TL;DR
Variations in performance for the finetuned model don't seem to trickle down to the sklearn models, so any choice would be okay.
Balanced sampling seems fine to go with for now, so this is what we currently have (and it is very marginally better).


## Class weights

Results for https://github.com/WorldCereal/presto-worldcereal/pull/46/commits/cb55f93554ec30d1700754d5ecc142ff29c036bb below ([wandb run](https://wandb.ai/nasa-harvest/presto-worldcereal/runs/cfinervi)): 

Interestingly, fixing the finetuning weights :bug: seems to lead to much worse finetuning results for the maize model (F1: 0.6711 vs. 0.8081 [before](https://github.com/WorldCereal/presto-worldcereal/pull/44)). This seems to also impact the sklearn models trained on top of this model (except for the random forest and catboost models).

| Task | Model | Head | F1 | Recall | Precision |
| --- | --- | --- | --- | --- | --- |
| Crop vs. non crop | WorldCereal | CatBoost | 0.8489 | 0.8518 | 0.8462 |
| Crop vs. non crop | Full, Crop vs. non crop | Finetuned | 0.8572 | 0.9070 | 0.8126 |
| Crop vs. non crop | Full, Crop vs. non crop | Random Forest | 0.8665 | 0.8425 | 0.8919 |
| Crop vs. non crop | Full, Crop vs. non crop | Logistic Regression | 0.8591 | 0.9113 | 0.8125 |
| Crop vs. non crop | Full, Crop vs. non crop | CatBoost | 0.8626 | 0.9079 | 0.8216 |
| Maize | Full, Maize | Finetuned | 0.6711 | 0.9266 | 0.5261 |
| Maize | Full, Maize | Random Forest | 0.8 | 0.7360 | 0.8762 | 
| Maize | Full, Maize | Logistic Regression | 0.7049 | 0.9176 | 0.5723 |
| Maize | Full, Maize | CatBoost | 0.7589 | 0.8901 | 0.6614 |
| Maize | Full, Crop vs. Non Crop | Random Forest | 0.6712 | 0.5453 | 0.8725 |
| Maize | Full, Crop vs. Non Crop | Logistic Regression | 0.5462 | 0.8855 | 0.3949 | 
| Maize | Full, Crop vs. Non Crop | CatBoost | 0.6940 | 0.8739 | 0.5755 |

For maize, the imbalance (and therefore the `pos_weight`) is very high:

```python
>>> weights = torch.from_numpy(train_ds.class_weights)
>>> weights
tensor([0.5490, 5.6046], dtype=torch.float64)
>>> (weights / weights[0])[1]
tensor(10.2093, dtype=torch.float64)
```
Having such a high weight seems bad to me? I think three solutions would be:
- [ ] lower the learning rate (reluctant to do this since it would need to be done dynamically depending on the weights and this seems finicky)
- [x] prevent the class weight from getting too high (or low): https://github.com/WorldCereal/presto-worldcereal/pull/46/commits/a11897f8ffd318bf5dfff19fab26ccfd9e995af6 - results in the table below
- [x] balancing the samples in the batch, removing the need for a class weight entirely without messing about with the loss's magnitude: https://github.com/WorldCereal/presto-worldcereal/pull/46/commits/3cf5e9531bb0efab85eb97240b64e1ca533ee598

## Clamped class weights

Results from the [experiment](https://wandb.ai/nasa-harvest/presto-worldcereal/runs/kb9bg4cc) with clamped class weights at finetuning time. Better (maize) finetuning results but actually not a huge difference for the sklearn models.

| Task | Model | Head | F1 | Recall | Precision |
| --- | --- | --- | --- | --- | --- |
| Crop vs. non crop | WorldCereal | CatBoost | 0.8489 | 0.8518 | 0.8462 |
| Crop vs. non crop | Full, Crop vs. non crop | Finetuned | 0.8601 | 0.8832 | 0.8381 |
| Crop vs. non crop | Full, Crop vs. non crop | Random Forest | 0.8624 | 0.8390 | 0.8873 |
| Crop vs. non crop | Full, Crop vs. non crop | Logistic Regression | 0.8540 | 0.9054 | 0.8081 |
| Crop vs. non crop | Full, Crop vs. non crop | CatBoost | 0.8590 | 0.90742| 0.8181 |
| Maize | Full, Maize | Finetuned | 0.8059 | 0.8330 | 0.7806 |
| Maize | Full, Maize | Random Forest | 0.8053 | 0.7397 | 0.8836 | 
| Maize | Full, Maize | Logistic Regression | 0.7168 | 0.9187 | 0.5876 |
| Maize | Full, Maize | CatBoost | 0.7712 | 0.8897 | 0.6806 |
| Maize | Full, Crop vs. Non Crop | Random Forest | 0.6675 | 0.5419 | 0.8690 |
| Maize | Full, Crop vs. Non Crop | Logistic Regression | 0.5410 | 0.8803 | 0.3905 | 
| Maize | Full, Crop vs. Non Crop | CatBoost | 0.6822 | 0.8688 | 0.5616 |

## Balanced sampling

Results from the [experiment](https://wandb.ai/nasa-harvest/presto-worldcereal/runs/34tjmqq1) with balanced sampling at finetuning time.

| Task | Model | Head | F1 | Recall | Precision |
| --- | --- | --- | --- | --- | --- |
| Crop vs. non crop | WorldCereal | CatBoost | 0.8489 | 0.8518 | 0.8462 |
| Crop vs. non crop | Full, Crop vs. non crop | Finetuned | 0.8652 | 0.8841 | 0.8471 |
| Crop vs. non crop | Full, Crop vs. non crop | Random Forest | 0.8661 | 0.8424 | 0.8910 |
| Crop vs. non crop | Full, Crop vs. non crop | Logistic Regression | 0.8581 | 0.9098 | 0.8119 |
| Crop vs. non crop | Full, Crop vs. non crop | CatBoost | 0.8631 | 0.9076 | 0.8228 |
| Maize | Full, Maize | Finetuned | 0.7460 | 0.9085 | 0.6328 |
| Maize | Full, Maize | Random Forest | 0.8068 | 0.7455 | 0.8791 | 
| Maize | Full, Maize | Logistic Regression | 0.7276 | 0.9207 | 0.6015 |
| Maize | Full, Maize | CatBoost | 0.7717 | 0.8912 | 0.6805 |
| Maize | Full, Crop vs. Non Crop | Random Forest | 0.6687 | 0.5416 | 0.8690 |
| Maize | Full, Crop vs. Non Crop | Logistic Regression | 0.5457 | 0.8815 | 0.3952 | 
| Maize | Full, Crop vs. Non Crop | CatBoost | 0.6879 | 0.8737 | 0.5673 |
