### PR TITLE
Multi class pretraining

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -7,5 +7,7 @@
     "encoder_num_heads": 8,
     "decoder_embedding_size": 128,
     "decoder_depth": 2,
-    "decoder_num_heads": 8
+    "decoder_num_heads": 8,
+    "valid_month_as_token": false,
+    "valid_month_size": 32
 }

--- a/presto/dataset.py
+++ b/presto/dataset.py
@@ -188,6 +188,10 @@ def target_maize(row_d) -> int:
     return int(row_d["CROPTYPE_LABEL"] == 1200)
 
 
+def target_croptype(row_d) -> int:
+    return int(row_d["CROPTYPE_LABEL"])
+
+
 class WorldCerealLabelledDataset(WorldCerealBase):
     # 0: no information, 10: could be both annual or perennial
     FILTER_LABELS = [0, 10]

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -92,6 +92,7 @@ class WorldCerealEvalBase:
 
 
 class WorldCerealFinetuning(WorldCerealEvalBase):
+    name = "WorldCerealFineTuning"
     regression = False
 
     def __init__(
@@ -329,15 +330,7 @@ class WorldCerealEval(WorldCerealEvalBase):
                 class_weight=class_weight_dict,
                 random_state=self.seed,
             ),
-            # Parameters emulate
-            # https://github.com/WorldCereal/wc-classification/blob/
-            # 4a9a839507d9b4f63c378b3b1d164325cbe843d6/src/worldcereal/classification/models.py#L490
             "CatBoostClassifier": CatBoostClassifier(
-                iterations=8000,
-                depth=8,
-                learning_rate=0.05,
-                early_stopping_rounds=20,
-                l2_leaf_reg=3,
                 random_state=self.seed,
                 class_weights=class_weight_dict,
             ),

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -34,9 +34,9 @@ SklearnStyleModel = Union[BaseEstimator, CatBoostClassifier]
 
 @dataclass
 class Hyperparams:
-    lr: float = 3e-4
+    lr: float = 2e-5
     max_epochs: int = 100
-    batch_size: int = 128
+    batch_size: int = 64
     patience: int = 3
     num_workers: int = 4
 

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -83,7 +83,7 @@ class WorldCerealEvalBase:
 
     def val_ds(self, balance: bool = False):
         return WorldCerealLabelledDataset(
-            self.val_ds,
+            self.val_df,
             countries_to_remove=self.countries_to_remove,
             years_to_remove=self.years_to_remove,
             target_function=self.target_function,

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -183,7 +183,7 @@ class WorldCerealFinetuning(WorldCerealEvalBase):
                     latlons=latlons,
                     month=month,
                 )
-                loss = loss_fn(preds, y.float())
+                loss = loss_fn(preds, y.long())
                 epoch_train_loss += loss.item()
                 loss.backward()
                 optimizer.step()
@@ -204,7 +204,7 @@ class WorldCerealFinetuning(WorldCerealEvalBase):
                         month=month,
                     )
                     all_preds.append(preds)
-                    all_y.append(y.float())
+                    all_y.append(y.long())
 
             val_loss.append(loss_fn(torch.cat(all_preds), torch.cat(all_y)))
             pbar.set_description(f"Train metric: {train_loss[-1]}, Val metric: {val_loss[-1]}")

--- a/presto/eval.py
+++ b/presto/eval.py
@@ -34,9 +34,9 @@ SklearnStyleModel = Union[BaseEstimator, CatBoostClassifier]
 
 @dataclass
 class Hyperparams:
-    lr: float = 2e-5
-    max_epochs: int = 20
-    batch_size: int = 64
+    lr: float = 3e-4
+    max_epochs: int = 100
+    batch_size: int = 128
     patience: int = 3
     num_workers: int = 4
 

--- a/presto/presto.py
+++ b/presto/presto.py
@@ -474,7 +474,7 @@ class Encoder(nn.Module):
         x, upd_mask, orig_indices = self.add_token(latlon_tokens, x, upd_mask, orig_indices)
 
         if valid_month is not None:
-            val_month_token = self.valid_month_encoding(valid_month)
+            val_month_token = self.valid_month_encoding(valid_month).unsqueeze(1)
             x, upd_mask, orig_indices = self.add_token(val_month_token, x, upd_mask, orig_indices)
 
         # apply Transformer blocks

--- a/presto/presto.py
+++ b/presto/presto.py
@@ -803,7 +803,7 @@ class Presto(nn.Module):
 
     @classmethod
     def load_pretrained(
-        cls, model_path: Union[str, Path] = default_model_path, strict: bool = True
+        cls, model_path: Union[str, Path] = default_model_path, strict: bool = False
     ):
         model = cls.construct()
         model.load_state_dict(torch.load(model_path, map_location=device), strict=strict)

--- a/presto/presto.py
+++ b/presto/presto.py
@@ -481,9 +481,11 @@ class Encoder(nn.Module):
         x, upd_mask, orig_indices = self.add_token(latlon_tokens, x, upd_mask, orig_indices)
 
         if valid_month is not None:
-            val_month_token = self.valid_month_encoding(valid_month).unsqueeze(1)
+            val_month_token = self.valid_month_encoding(valid_month)
         if self.valid_month_as_token:
-            x, upd_mask, orig_indices = self.add_token(val_month_token, x, upd_mask, orig_indices)
+            x, upd_mask, orig_indices = self.add_token(
+                val_month_token.unsqueeze(1), x, upd_mask, orig_indices
+            )
 
         # apply Transformer blocks
         for blk in self.blocks:
@@ -494,7 +496,7 @@ class Encoder(nn.Module):
             # set masked tokens to 0
             x_for_mean = x * (1 - upd_mask.unsqueeze(-1))
             x_mean = x_for_mean.sum(dim=1) / torch.sum(1 - upd_mask, -1, keepdim=True)
-            return torch.cat([self.norm(x_mean), val_month_token], axis=-1)
+            return torch.cat([self.norm(x_mean), val_month_token], dim=-1)
         return self.norm(x), orig_indices, upd_mask
 
 

--- a/presto/presto.py
+++ b/presto/presto.py
@@ -333,7 +333,9 @@ class Encoder(nn.Module):
             num_embeddings=len(self.band_groups) + 1, embedding_dim=channel_embedding_size
         )
 
-        self.valid_month_encoding = nn.Embedding(num_embeddings=12, embedding_dim=embedding_size)
+        self.valid_month_encoding = nn.Embedding.from_pretrained(
+            get_month_encoding_table(embedding_size)
+        )
 
         self.initialize_weights()
 

--- a/presto/presto.py
+++ b/presto/presto.py
@@ -704,6 +704,7 @@ class PrestoFineTuningModel(nn.Module):
         latlons: torch.Tensor,
         mask: Optional[torch.Tensor] = None,
         month: Union[torch.Tensor, int] = 0,
+        valid_month: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         return self.head(
             self.encoder(
@@ -712,6 +713,7 @@ class PrestoFineTuningModel(nn.Module):
                 latlons=latlons,
                 mask=mask,
                 month=month,
+                valid_month=valid_month,
                 eval_task=True,
             )
         )

--- a/tests/test_presto.py
+++ b/tests/test_presto.py
@@ -263,7 +263,7 @@ class TestPresto(TestCase):
         all 3 ways of loading the pretrained model are in agreement
         """
         model = Presto.construct()
-        model.load_state_dict(torch.load(default_model_path, map_location=device))
+        model.load_state_dict(torch.load(default_model_path, map_location=device), strict=False)
 
         from_function = Presto.load_pretrained()
         for torch_loaded, pretrain_loaded in zip(model.parameters(), from_function.parameters()):
@@ -321,7 +321,11 @@ class TestPresto(TestCase):
         output.backward()
 
         for name, param in encoder.named_parameters():
-            if ("pos_embed" not in name) and ("month_embed" not in name):
+            if (
+                ("pos_embed" not in name)
+                and ("month_embed" not in name)
+                and ("valid_month_encoding" not in name)
+            ):
                 # the positional encoder is frozen
                 self.assertIsNotNone(param.grad, msg=name)
 
@@ -353,7 +357,9 @@ class TestPresto(TestCase):
     def test_load_pretrained_works_for_finetuned_model(self):
         path_to_finetuned_model = data_dir / "finetuned_model.pt"
         model = Presto.load_pretrained().construct_finetuning_model(num_outputs=1)
-        model.load_state_dict(torch.load(path_to_finetuned_model, map_location=device))
+        model.load_state_dict(
+            torch.load(path_to_finetuned_model, map_location=device), strict=False
+        )
 
         model_2 = Presto.load_pretrained(path_to_finetuned_model, strict=False)
 

--- a/tests/test_presto.py
+++ b/tests/test_presto.py
@@ -364,7 +364,9 @@ class TestPresto(TestCase):
 
     def test_load_pretrained_works_for_finetuned_model(self):
         path_to_finetuned_model = data_dir / "finetuned_model.pt"
-        model = Presto.load_pretrained().construct_finetuning_model(num_outputs=1)
+        model = Presto.load_pretrained(valid_month_as_token=True).construct_finetuning_model(
+            num_outputs=1
+        )
         model.load_state_dict(
             torch.load(path_to_finetuned_model, map_location=device), strict=False
         )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,6 +17,7 @@ def read_test_file() -> pd.DataFrame:
         axis=1,
         inplace=True,
     )
+    test_df["valid_date"] = test_df["start_date"]
     test_df["sample_id"] = np.arange(len(test_df))
     test_df["year"] = 2021
     labels = [99] * len(test_df)  # 99 = No cropland

--- a/train.py
+++ b/train.py
@@ -3,27 +3,16 @@ import argparse
 import json
 import logging
 from pathlib import Path
-from typing import Optional, Tuple, cast
+from typing import Optional, cast
 
 import pandas as pd
 import torch
-import torch.nn as nn
 import xarray as xr
-from torch import optim
-from torch.utils.data import DataLoader
-from tqdm import tqdm
 
-from presto.dataops import BANDS_GROUPS_IDX
 from presto.dataset import WorldCerealMaskedDataset as WorldCerealDataset
 from presto.dataset import filter_remove_noncrops, target_maize
 from presto.eval import WorldCerealEval, WorldCerealFinetuning
-from presto.masking import MASK_STRATEGIES, MaskParamsNoDw
-from presto.presto import (
-    LossWrapper,
-    Presto,
-    adjust_learning_rate,
-    param_groups_weight_decay,
-)
+from presto.presto import Presto
 from presto.utils import (
     DEFAULT_SEED,
     config_dir,
@@ -51,26 +40,6 @@ argparser.add_argument(
     "and <output_dir>/output/ will be written to. "
     "Leave empty to use the directory you are running this file from.",
 )
-argparser.add_argument("--n_epochs", type=int, default=20)
-argparser.add_argument("--max_learning_rate", type=float, default=0.0001)
-argparser.add_argument("--min_learning_rate", type=float, default=0.0)
-argparser.add_argument("--warmup_epochs", type=int, default=2)
-argparser.add_argument("--weight_decay", type=float, default=0.05)
-argparser.add_argument("--batch_size", type=int, default=4096)
-argparser.add_argument("--val_per_n_steps", type=int, default=-1, help="If -1, val every epoch")
-argparser.add_argument(
-    "--mask_strategies",
-    type=str,
-    default=[
-        "group_bands",
-        "random_timesteps",
-        "chunk_timesteps",
-        "random_combinations",
-    ],
-    nargs="+",
-    help="`all` will use all available masking strategies (including single bands)",
-)
-argparser.add_argument("--mask_ratio", type=float, default=0.75)
 argparser.add_argument("--seed", type=int, default=DEFAULT_SEED)
 argparser.add_argument("--num_workers", type=int, default=4)
 argparser.add_argument("--wandb", dest="wandb", action="store_true")
@@ -109,30 +78,12 @@ model_logging_dir.mkdir(exist_ok=True, parents=True)
 initialize_logging(model_logging_dir)
 logger.info("Using output dir: %s" % model_logging_dir)
 
-num_epochs = args["n_epochs"]
-val_per_n_steps = args["val_per_n_steps"]
-max_learning_rate = args["max_learning_rate"]
-min_learning_rate = args["min_learning_rate"]
-warmup_epochs = args["warmup_epochs"]
-weight_decay = args["weight_decay"]
-batch_size = args["batch_size"]
-
-# Default mask strategies and mask_ratio
-mask_strategies: Tuple[str, ...] = tuple(args["mask_strategies"])
-if (len(mask_strategies) == 1) and (mask_strategies[0] == "all"):
-    mask_strategies = MASK_STRATEGIES
-mask_ratio: float = args["mask_ratio"]
-
 parquet_file: str = args["parquet_file"]
 val_samples_file: str = args["val_samples_file"]
 
 path_to_config = config_dir / "default.json"
 model_kwargs = json.load(Path(path_to_config).open("r"))
 
-logger.info("Setting up dataloaders")
-
-# Load the mask parameters
-mask_params = MaskParamsNoDw(mask_strategies, mask_ratio)
 
 df = pd.read_parquet(data_dir / parquet_file)
 if (data_dir / val_samples_file).exists():
@@ -141,26 +92,14 @@ if (data_dir / val_samples_file).exists():
     train_df, val_df = WorldCerealDataset.split_df(df, val_sample_ids=val_samples)
 else:
     train_df, val_df = WorldCerealDataset.split_df(df)
-train_dataloader = DataLoader(
-    WorldCerealDataset(train_df, mask_params=mask_params),
-    batch_size=batch_size,
-    shuffle=True,
-    num_workers=num_workers,
-)
-val_dataloader = DataLoader(
-    WorldCerealDataset(val_df, mask_params=mask_params),
-    batch_size=batch_size,
-    shuffle=False,
-    num_workers=num_workers,
-)
-
-if val_per_n_steps == -1:
-    val_per_n_steps = len(train_dataloader)
 
 logger.info("Setting up model")
 if warm_start:
     model_kwargs = json.load(Path(config_dir / "default.json").open("r"))
-    model = Presto.load_pretrained()
+    model = Presto.load_pretrained(
+        valid_month_as_token=model_kwargs["valid_month_as_token"],
+        valid_month_size=model_kwargs["valid_month_size"],
+    )
     best_model_path: Optional[Path] = default_model_path
 else:
     if path_to_config == "":
@@ -169,157 +108,6 @@ else:
     model = Presto.construct(**model_kwargs)
     best_model_path = None
 model.to(device)
-
-param_groups = param_groups_weight_decay(model, weight_decay)
-optimizer = optim.AdamW(param_groups, lr=max_learning_rate, betas=(0.9, 0.95))
-mse = LossWrapper(nn.MSELoss())
-
-training_config = {
-    "model": model.__class__,
-    "encoder": model.encoder.__class__,
-    "decoder": model.decoder.__class__,
-    "optimizer": optimizer.__class__.__name__,
-    "eo_loss": mse.loss.__class__.__name__,
-    "device": device,
-    "logging_dir": model_logging_dir,
-    **args,
-    **model_kwargs,
-}
-
-if wandb_enabled:
-    wandb.config.update(training_config)
-
-lowest_validation_loss = None
-best_val_epoch = 0
-training_step = 0
-num_validations = 0
-
-with tqdm(range(num_epochs), desc="Epoch") as tqdm_epoch:
-    for epoch in tqdm_epoch:
-        # ------------------------ Training ----------------------------------------
-        total_eo_train_loss = 0.0
-        num_updates_being_captured = 0
-        train_size = 0
-        model.train()
-        for epoch_step, b in enumerate(tqdm(train_dataloader, desc="Train", leave=False)):
-            mask, x, y, start_month = b[0].to(device), b[2].to(device), b[3].to(device), b[6]
-            dw_mask, x_dw, y_dw = b[1].to(device), b[4].to(device).long(), b[5].to(device).long()
-            latlons, real_mask = b[7].to(device), b[9].to(device)
-            # zero the parameter gradients
-            optimizer.zero_grad()
-            lr = adjust_learning_rate(
-                optimizer,
-                epoch_step / len(train_dataloader) + epoch,
-                warmup_epochs,
-                num_epochs,
-                max_learning_rate,
-                min_learning_rate,
-            )
-            # Get model outputs and calculate loss
-            y_pred, dw_pred = model(
-                x, mask=mask, dynamic_world=x_dw, latlons=latlons, month=start_month
-            )
-            # set all SRTM timesteps except the first one to unmasked, so that
-            # they will get ignored by the loss function even if the SRTM
-            # value was masked
-            mask[:, 1:, BANDS_GROUPS_IDX["SRTM"]] = False
-            # set the "truly masked" values to unmasked, so they also get ignored in the loss
-            mask[real_mask] = False
-            loss = mse(y_pred[mask], y[mask])
-            loss.backward()
-            optimizer.step()
-
-            current_batch_size = len(x)
-            total_eo_train_loss += loss.item()
-            num_updates_being_captured += 1
-            train_size += current_batch_size
-            training_step += 1
-
-            # ------------------------ Validation --------------------------------------
-            if training_step % val_per_n_steps == 0:
-                total_eo_val_loss = 0.0
-                num_val_updates_captured = 0
-                val_size = 0
-                model.eval()
-
-                with torch.no_grad():
-                    for b in tqdm(val_dataloader, desc="Validate"):
-                        mask, x, y, start_month, real_mask = (
-                            b[0].to(device),
-                            b[2].to(device),
-                            b[3].to(device),
-                            b[6],
-                            b[9].to(device),
-                        )
-                        dw_mask, x_dw = b[1].to(device), b[4].to(device).long()
-                        y_dw, latlons = b[5].to(device).long(), b[7].to(device)
-                        # Get model outputs and calculate loss
-                        y_pred, dw_pred = model(
-                            x, mask=mask, dynamic_world=x_dw, latlons=latlons, month=start_month
-                        )
-                        # set all SRTM timesteps except the first one to unmasked, so that
-                        # they will get ignored by the loss function even if the SRTM
-                        # value was masked
-                        mask[:, 1:, BANDS_GROUPS_IDX["SRTM"]] = False
-                        # set the "truly masked" values to unmasked, so they also get
-                        # ignored in the loss
-                        mask[real_mask] = False
-                        loss = mse(y_pred[mask], y[mask])
-                        current_batch_size = len(x)
-                        total_eo_val_loss += loss.item()
-                        num_val_updates_captured += 1
-
-                # ------------------------ Metrics + Logging -------------------------------
-                # train_loss now reflects the value against which we calculate gradients
-                train_eo_loss = total_eo_train_loss / num_updates_being_captured
-                val_eo_loss = total_eo_val_loss / num_val_updates_captured
-
-                if "train_size" not in training_config and "val_size" not in training_config:
-                    training_config["train_size"] = train_size
-                    training_config["val_size"] = val_size
-                    if wandb_enabled:
-                        wandb.config.update(training_config)
-
-                to_log = {
-                    "train_eo_loss": train_eo_loss,
-                    "val_eo_loss": val_eo_loss,
-                    "training_step": training_step,
-                    "epoch": epoch,
-                    "lr": lr,
-                }
-                tqdm_epoch.set_postfix(loss=val_eo_loss)
-
-                if lowest_validation_loss is None or val_eo_loss < lowest_validation_loss:
-                    lowest_validation_loss = val_eo_loss
-                    best_val_epoch = epoch
-
-                    model_path = model_logging_dir / Path("models")
-                    model_path.mkdir(exist_ok=True, parents=True)
-
-                    best_model_path = model_path / f"{model_name}{epoch}.pt"
-                    logger.info(f"Saving best model to: {best_model_path}")
-                    torch.save(model.state_dict(), best_model_path)
-
-                # reset training logging
-                total_eo_train_loss = 0.0
-                num_updates_being_captured = 0
-                train_size = 0
-                num_validations += 1
-
-                if wandb_enabled:
-                    wandb.log(to_log)
-
-                model.train()
-
-logger.info(f"Trained for {num_epochs} epochs, best model at {best_model_path}")
-
-if best_model_path is not None:
-    logger.info("Loading best model: %s" % best_model_path)
-    best_model = torch.load(best_model_path, map_location=device)
-    model.load_state_dict(best_model, strict=False)
-else:
-    logger.info("Running eval with randomly init weights")
-
 
 # full finetuning
 full_finetuning = WorldCerealFinetuning(train_df, val_df)

--- a/train.py
+++ b/train.py
@@ -315,7 +315,7 @@ logger.info(f"Trained for {num_epochs} epochs, best model at {best_model_path}")
 
 if best_model_path is not None:
     logger.info("Loading best model: %s" % best_model_path)
-    best_model = torch.load(best_model_path, map_location=device)
+    best_model = torch.load(best_model_path, map_location=device, strict=False)
     model.load_state_dict(best_model)
 else:
     logger.info("Running eval with randomly init weights")

--- a/train.py
+++ b/train.py
@@ -315,8 +315,8 @@ logger.info(f"Trained for {num_epochs} epochs, best model at {best_model_path}")
 
 if best_model_path is not None:
     logger.info("Loading best model: %s" % best_model_path)
-    best_model = torch.load(best_model_path, map_location=device, strict=False)
-    model.load_state_dict(best_model)
+    best_model = torch.load(best_model_path, map_location=device)
+    model.load_state_dict(best_model, strict=False)
 else:
     logger.info("Running eval with randomly init weights")
 


### PR DESCRIPTION
As discussed. All the balancing implemented in #46 is ignored now, and can be removed if we merge this in.

| Task | Model | Head | F1 | Recall | Precision |
| --- | --- | --- | --- | --- | --- |
| Crop vs. non crop | Crop vs. non crop | Random Forest | 0.8661 | 0.8424. | 0.8910 |
| Crop vs. non crop | MultiClass | Random Forest | 0.8552 | 0.8207 | 0.8927 |
| Crop vs. non crop | MultiClass + `valid_date` as token | Random Forest | 0.8555 | 0.8167 | 0.8982 |
| Crop vs. non crop | Crop vs. non crop | Logistic Regression | 0.8581 | 0.9098  | 0.8119 |
| Crop vs. non crop | MultiClass | Logistic Regression | 0.8179 | 0.8764 | 0.7667 |
| Crop vs. non crop | MultiClass + `valid_date` as token | Logistic Regression | 0.8189 | 0.8770 | 0.7681 |
| Crop vs. non crop | Crop vs. non crop | CatBoost | 0.8631 | 0.9076 | 0.8228 |
| Crop vs. non crop | MultiClass | CatBoost | 0.8567 | 0.8992 | 0.8181 |
| Crop vs. non crop | Multiclass + `valid_date` as token | CatBoost | 0.8591 | 0.8982 | 0.8232 |
| Maize | Maize | Random Forest | 0.8068 | 0.7455 | 0.8791 |
| Maize | MultiClass | Random Forest | 0.7548 | 0.6944 | 0.8266 | 
| Maize | MultiClass + `valid_date` as token | Random Forest | 0.7663 | 0.7059 | 0.8380 |
| Maize | Maize | Logistic Regression | 0.7276  | 0.9207 | 0.6015 |
| Maize | MultiClass | Logistic Regression | 0.5730 | 0.9126 | 0.4176 |
| Maize | MultiClass + `valid_date` as token | Logistic Regression | 0.6034 | 0.9153 | 0.4500 |
| Maize | Maize | CatBoost | 0.7717 | 0.8912 | 0.6805 |
| Maize | MultiClass | CatBoost | 0.6472 | 0.8970 | 0.5063 |
| Maize | MultiClass + `valid_date` as token | CatBoost | 0.6560 | 0.9005 | 0.5159 |