### PR TITLE
fix: latlon handling in inference dataset

### DIFF
--- a/presto/dataset.py
+++ b/presto/dataset.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 import rioxarray
 import xarray as xr
-from einops import rearrange, repeat
+from einops import rearrange
 from pyproj import Transformer
 from sklearn.utils.class_weight import compute_class_weight
 from torch.utils.data import Dataset

--- a/presto/dataset.py
+++ b/presto/dataset.py
@@ -351,12 +351,8 @@ class WorldCerealInferenceDataset(Dataset):
         months = np.ones((num_instances)) * start_month
 
         transformer = Transformer.from_crs(f"EPSG:{epsg_coords}", "EPSG:4326", always_xy=True)
-        lon, lat = transformer.transform(ds.x, ds.y)
-
-        latlons = np.stack(
-            [np.repeat(lat, repeats=len(lon)), repeat(lon, "c -> (h c)", h=len(lat))],
-            axis=-1,
-        )
+        lon, lat = transformer.transform(np.meshgrid(ds.x, ds.y))
+        latlons = rearrange(np.stack([lat, lon]), "c x y -> (x y) c")
 
         return eo_data, np.repeat(mask, BAND_EXPANSION, axis=-1), latlons, months, y
 

--- a/presto/dataset.py
+++ b/presto/dataset.py
@@ -351,7 +351,7 @@ class WorldCerealInferenceDataset(Dataset):
         months = np.ones((num_instances)) * start_month
 
         transformer = Transformer.from_crs(f"EPSG:{epsg_coords}", "EPSG:4326", always_xy=True)
-        lon, lat = transformer.transform(np.meshgrid(ds.x, ds.y))
+        lon, lat = transformer.transform(*np.meshgrid(ds.x, ds.y))
         latlons = rearrange(np.stack([lat, lon]), "c x y -> (x y) c")
 
         return eo_data, np.repeat(mask, BAND_EXPANSION, axis=-1), latlons, months, y

--- a/presto/dataset.py
+++ b/presto/dataset.py
@@ -351,7 +351,8 @@ class WorldCerealInferenceDataset(Dataset):
         months = np.ones((num_instances)) * start_month
 
         transformer = Transformer.from_crs(f"EPSG:{epsg_coords}", "EPSG:4326", always_xy=True)
-        lon, lat = transformer.transform(*np.meshgrid(ds.x, ds.y))
+        lon, lat = np.meshgrid(ds.x, ds.y)
+        lon, lat = transformer.transform(lon, lat)
         latlons = rearrange(np.stack([lat, lon]), "c x y -> (x y) c")
 
         return eo_data, np.repeat(mask, BAND_EXPANSION, axis=-1), latlons, months, y


### PR DESCRIPTION
@gabrieltseng the inference dataset had a bug in latlon handling. Only "worked" for square patches but even then contained a bug. This should go through a meshgrid. Made a fix for this. I'm not really familiar with `einops.rearrange` so please check if I did this the right way. One approved, we should be ok to move this right into `main`.