### PR TITLE
Isolated `prep_dataframe` method

### DIFF
--- a/presto/inference.py
+++ b/presto/inference.py
@@ -60,9 +60,7 @@ class PrestoFeatureExtractor:
     }
 
     @classmethod
-    def _preprocess_band_values(
-        cls, values: np.ndarray, presto_band: str
-    ) -> np.ndarray:
+    def _preprocess_band_values(cls, values: np.ndarray, presto_band: str) -> np.ndarray:
         """
         Preprocesses the band values based on the given presto_val.
 
@@ -150,9 +148,7 @@ class PrestoFeatureExtractor:
         """
         num_instances = len(inarr.x) * len(inarr.y)
 
-        start_month = (
-            inarr.t.values[0].astype("datetime64[M]").astype(int) % 12 + 1
-        ) - 1
+        start_month = (inarr.t.values[0].astype("datetime64[M]").astype(int) % 12 + 1) - 1
 
         months = np.ones((num_instances)) * start_month
         return months
@@ -246,19 +242,13 @@ class PrestoFeatureExtractor:
 
         return np.concatenate(all_encodings, axis=0)
 
-    def extract_presto_features(
-        self, inarr: xr.DataArray, epsg: int = 4326
-    ) -> xr.DataArray:
+    def extract_presto_features(self, inarr: xr.DataArray, epsg: int = 4326) -> xr.DataArray:
 
-        eo, dynamic_world, months, latlons, mask = self._create_presto_input(
-            inarr, epsg
-        )
+        eo, dynamic_world, months, latlons, mask = self._create_presto_input(inarr, epsg)
         dl = self._create_dataloader(eo, dynamic_world, months, latlons, mask)
 
         features = self._get_encodings(dl)
-        features = rearrange(
-            features, "(x y) c -> x y c", x=len(inarr.x), y=len(inarr.y)
-        )
+        features = rearrange(features, "(x y) c -> x y c", x=len(inarr.x), y=len(inarr.y))
         ft_names = [f"presto_ft_{i}" for i in range(128)]
         features_da = xr.DataArray(
             features,
@@ -398,16 +388,13 @@ def process_parquet(df: pd.DataFrame) -> pd.DataFrame:
         for xx in df_pivot.columns.to_flat_index()
     ]
     df_pivot.columns = [
-        f"{xx}-10m" if any(band in xx for band in bands10m) else xx
-        for xx in df_pivot.columns
+        f"{xx}-10m" if any(band in xx for band in bands10m) else xx for xx in df_pivot.columns
     ]
     df_pivot.columns = [
-        f"{xx}-20m" if any(band in xx for band in bands20m) else xx
-        for xx in df_pivot.columns
+        f"{xx}-20m" if any(band in xx for band in bands20m) else xx for xx in df_pivot.columns
     ]
     df_pivot.columns = [
-        f"{xx}-100m" if any(band in xx for band in bands100m) else xx
-        for xx in df_pivot.columns
+        f"{xx}-100m" if any(band in xx for band in bands100m) else xx for xx in df_pivot.columns
     ]
 
     df_pivot["start_date"] = df_pivot["start_date"].dt.date.astype(str)

--- a/presto/inference.py
+++ b/presto/inference.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, Tuple, Union
+from typing import Tuple, Union
 
 import numpy as np
 import pandas as pd

--- a/presto/inference.py
+++ b/presto/inference.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from typing import Callable, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -16,10 +16,9 @@ from .dataops import (
     DynamicWorld2020_2021,
 )
 from .dataset import WorldCerealBase
-from .eval import WorldCerealEval
 from .masking import BAND_EXPANSION
 from .presto import Presto
-from .utils import device
+from .utils import device, prep_dataframe
 
 # Index to band groups mapping
 IDX_TO_BAND_GROUPS = {
@@ -61,7 +60,9 @@ class PrestoFeatureExtractor:
     }
 
     @classmethod
-    def _preprocess_band_values(cls, values: np.ndarray, presto_band: str) -> np.ndarray:
+    def _preprocess_band_values(
+        cls, values: np.ndarray, presto_band: str
+    ) -> np.ndarray:
         """
         Preprocesses the band values based on the given presto_val.
 
@@ -149,7 +150,9 @@ class PrestoFeatureExtractor:
         """
         num_instances = len(inarr.x) * len(inarr.y)
 
-        start_month = (inarr.t.values[0].astype("datetime64[M]").astype(int) % 12 + 1) - 1
+        start_month = (
+            inarr.t.values[0].astype("datetime64[M]").astype(int) % 12 + 1
+        ) - 1
 
         months = np.ones((num_instances)) * start_month
         return months
@@ -243,13 +246,19 @@ class PrestoFeatureExtractor:
 
         return np.concatenate(all_encodings, axis=0)
 
-    def extract_presto_features(self, inarr: xr.DataArray, epsg: int = 4326) -> xr.DataArray:
+    def extract_presto_features(
+        self, inarr: xr.DataArray, epsg: int = 4326
+    ) -> xr.DataArray:
 
-        eo, dynamic_world, months, latlons, mask = self._create_presto_input(inarr, epsg)
+        eo, dynamic_world, months, latlons, mask = self._create_presto_input(
+            inarr, epsg
+        )
         dl = self._create_dataloader(eo, dynamic_world, months, latlons, mask)
 
         features = self._get_encodings(dl)
-        features = rearrange(features, "(x y) c -> x y c", x=len(inarr.x), y=len(inarr.y))
+        features = rearrange(
+            features, "(x y) c -> x y c", x=len(inarr.x), y=len(inarr.y)
+        )
         ft_names = [f"presto_ft_{i}" for i in range(128)]
         features_da = xr.DataArray(
             features,
@@ -389,19 +398,22 @@ def process_parquet(df: pd.DataFrame) -> pd.DataFrame:
         for xx in df_pivot.columns.to_flat_index()
     ]
     df_pivot.columns = [
-        f"{xx}-10m" if any(band in xx for band in bands10m) else xx for xx in df_pivot.columns
+        f"{xx}-10m" if any(band in xx for band in bands10m) else xx
+        for xx in df_pivot.columns
     ]
     df_pivot.columns = [
-        f"{xx}-20m" if any(band in xx for band in bands20m) else xx for xx in df_pivot.columns
+        f"{xx}-20m" if any(band in xx for band in bands20m) else xx
+        for xx in df_pivot.columns
     ]
     df_pivot.columns = [
-        f"{xx}-100m" if any(band in xx for band in bands100m) else xx for xx in df_pivot.columns
+        f"{xx}-100m" if any(band in xx for band in bands100m) else xx
+        for xx in df_pivot.columns
     ]
 
     df_pivot["start_date"] = df_pivot["start_date"].dt.date.astype(str)
     df_pivot["end_date"] = df_pivot["end_date"].dt.date.astype(str)
     df_pivot["valid_date"] = df_pivot["valid_date"].dt.date.astype(str)
 
-    df_pivot = WorldCerealEval.prep_dataframe(df_pivot)
+    df_pivot = prep_dataframe(df_pivot)
 
     return df_pivot

--- a/presto/utils.py
+++ b/presto/utils.py
@@ -51,9 +51,7 @@ def seed_everything(seed: int = DEFAULT_SEED):
     torch.backends.cudnn.benchmark = True
 
 
-def initialize_logging(
-    output_dir: Union[str, Path], to_file=True, logger_name="__main__"
-):
+def initialize_logging(output_dir: Union[str, Path], to_file=True, logger_name="__main__"):
     logger = logging.getLogger(logger_name)
     formatter = logging.Formatter(
         fmt="%(asctime)s - %(levelname)s - %(message)s",
@@ -118,9 +116,7 @@ def construct_single_presto_input(
     assert len(num_timesteps_list) > 0
     assert all(num_timesteps_list[0] == timestep for timestep in num_timesteps_list)
     num_timesteps = num_timesteps_list[0]
-    mask, x = torch.ones(num_timesteps, len(BANDS)), torch.zeros(
-        num_timesteps, len(BANDS)
-    )
+    mask, x = torch.ones(num_timesteps, len(BANDS)), torch.zeros(num_timesteps, len(BANDS))
 
     for band_group in [
         (s1, s1_bands, S1_BANDS),
@@ -136,9 +132,7 @@ def construct_single_presto_input(
 
         kept_output_bands = [x for x in output_bands if x not in REMOVED_BANDS]
         # construct a mapping from the input bands to the expected bands
-        kept_input_band_idxs = [
-            i for i, val in enumerate(input_bands) if val in kept_output_bands
-        ]
+        kept_input_band_idxs = [i for i, val in enumerate(input_bands) if val in kept_output_bands]
         kept_input_band_names = [val for val in input_bands if val in kept_output_bands]
 
         input_to_output_mapping = [BANDS.index(val) for val in kept_input_band_names]
@@ -200,16 +194,12 @@ def plot_results(
         plt.ylabel(ylabel)
 
     def plot_for_group(grp_df):
-        mrgd_country = world_df.merge(
-            grp_df, left_on="name", right_on="country", how="left"
-        )
+        mrgd_country = world_df.merge(grp_df, left_on="name", right_on="country", how="left")
         mrgd_country = mrgd_country.dropna(subset="model")
 
         grp_df_aez = grp_df.loc[~pd.isna(grp_df.aez)]
         grp_df_aez.loc[:, "aez"] = grp_df_aez.aez.astype(int)
-        mrgd_aez = aez_df.merge(
-            grp_df_aez, left_on="zoneID", right_on="aez", how="left"
-        )
+        mrgd_aez = aez_df.merge(grp_df_aez, left_on="zoneID", right_on="aez", how="left")
         mrgd_aez = mrgd_aez.dropna(subset="model")
 
         grp_df_y = grp_df.loc[pd.notna(grp_df.year)].sort_values("year")
@@ -271,12 +261,8 @@ def plot_results(
     country = metrics_df.metric.apply(
         lambda m: m.split(":")[-1].lstrip() if "country" in m else None
     )
-    aez = metrics_df.metric.apply(
-        lambda m: m.split(":")[-1].lstrip() if "aez" in m else None
-    )
-    year = metrics_df.metric.apply(
-        lambda m: m.split(":")[-1].lstrip() if "year" in m else None
-    )
+    aez = metrics_df.metric.apply(lambda m: m.split(":")[-1].lstrip() if "aez" in m else None)
+    year = metrics_df.metric.apply(lambda m: m.split(":")[-1].lstrip() if "year" in m else None)
     model = metrics_df.metric.apply(lambda m: m.split("_")[1].strip())
     metrics_df = pd.concat((metrics_df, model, aez, year, country), axis=1)
     metrics_df.columns = ["metric", "value", "model", "aez", "year", "country"]
@@ -286,12 +272,8 @@ def plot_results(
         lambda x: "_".join(x[-2:]) if x[-2] not in metrics_df.model.unique() else x[-1]
     )
     # e.g. f1, recall, precision
-    metrics_df["metric_type"] = metrics_df.metric_wo_model.str.split(
-        ":", expand=True
-    ).loc[:, 0]
-    metrics_df["metric_type"] = (
-        metrics_df["metric_type"].str.split("_").apply(lambda x: x[-1])
-    )
+    metrics_df["metric_type"] = metrics_df.metric_wo_model.str.split(":", expand=True).loc[:, 0]
+    metrics_df["metric_type"] = metrics_df["metric_type"].str.split("_").apply(lambda x: x[-1])
     # add catboost performance to other model's rows to plot difference
     metrics_df = metrics_df.merge(
         metrics_df.loc[metrics_df.model == "CatBoost"],
@@ -338,9 +320,7 @@ def prep_dataframe(
     presto inference on OpenEO.
     """
     # SAR cannot equal 0.0 since we take the log of it
-    cols = [
-        f"SAR-{s}-ts{t}-20m" for s in ["VV", "VH"] for t in range(36 if dekadal else 12)
-    ]
+    cols = [f"SAR-{s}-ts{t}-20m" for s in ["VV", "VH"] for t in range(36 if dekadal else 12)]
 
     df = df.drop_duplicates(subset=["sample_id", "lat", "lon", "end_date"])
     df = df[~pd.isna(df).any(axis=1)]

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     long_description_content_type="text/markdown",
     author="Gabriel Tseng",
     author_email="gabrieltseng95@gmail.com",
-    version="0.1.1",
+    version="0.1.2",
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: Other/Proprietary License",


### PR DESCRIPTION
This seemed necessary because `prep_dataframe` was being reused in `nference.py`. This brought a lot of imports with it, and our inference chain failed on missing CatBoost library in OpenEO environment. It seems unnecessary to do all these imports just for processing the parquet files.