### PR TITLE
Test compilation for inference

### DIFF
--- a/presto/dataset.py
+++ b/presto/dataset.py
@@ -113,7 +113,17 @@ class WorldCerealBase(Dataset):
         )
 
     def __getitem__(self, idx):
-        raise NotImplementedError
+        # Get the sample
+        row = self.df.iloc[idx, :]
+        eo, mask_per_token, latlon, month, _ = self.row_to_arrays(row, self.target_crop)
+        mask_per_variable = np.repeat(mask_per_token, BAND_EXPANSION, axis=1)
+        return (
+            self.normalize_and_mask(eo),
+            np.ones(self.NUM_TIMESTEPS) * (DynamicWorld2020_2021.class_amount),
+            latlon,
+            month,
+            mask_per_variable,
+        )
 
     @classmethod
     def normalize_and_mask(cls, eo: np.ndarray):
@@ -195,23 +205,6 @@ class WorldCerealBase(Dataset):
         train = df[is_train]
         val = df[is_val]
         return train, val
-
-
-class WorldCerealDataset(WorldCerealBase):
-    # The simplest pd.DataFrame based dataset just
-    # for inference without labels
-    def __getitem__(self, idx):
-        # Get the sample
-        row = self.df.iloc[idx, :]
-        eo, mask_per_token, latlon, month, _ = self.row_to_arrays(row, self.target_crop)
-        mask_per_variable = np.repeat(mask_per_token, BAND_EXPANSION, axis=1)
-        return (
-            self.normalize_and_mask(eo),
-            np.ones(self.NUM_TIMESTEPS) * (DynamicWorld2020_2021.class_amount),
-            latlon,
-            month,
-            mask_per_variable,
-        )
 
 
 class WorldCerealMaskedDataset(WorldCerealBase):

--- a/presto/dataset.py
+++ b/presto/dataset.py
@@ -197,6 +197,23 @@ class WorldCerealBase(Dataset):
         return train, val
 
 
+class WorldCerealDataset(WorldCerealBase):
+    # The simplest pd.DataFrame based dataset just
+    # for inference without labels
+    def __getitem__(self, idx):
+        # Get the sample
+        row = self.df.iloc[idx, :]
+        eo, mask_per_token, latlon, month, _ = self.row_to_arrays(row, self.target_crop)
+        mask_per_variable = np.repeat(mask_per_token, BAND_EXPANSION, axis=1)
+        return (
+            self.normalize_and_mask(eo),
+            np.ones(self.NUM_TIMESTEPS) * (DynamicWorld2020_2021.class_amount),
+            latlon,
+            month,
+            mask_per_variable,
+        )
+
+
 class WorldCerealMaskedDataset(WorldCerealBase):
     def __init__(self, dataframe: pd.DataFrame, mask_params: MaskParamsNoDw):
         super().__init__(dataframe)

--- a/presto/inference.py
+++ b/presto/inference.py
@@ -1,6 +1,6 @@
 import functools
 import logging
-from typing import Tuple, Union
+from typing import Any, Callable, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -421,7 +421,7 @@ def process_parquet(df: pd.DataFrame) -> pd.DataFrame:
 
 
 @functools.lru_cache(maxsize=6)
-def compile_encoder(presto_encoder: nn.Module) -> nn.Module:
+def compile_encoder(presto_encoder: nn.Module) -> Callable[..., Any]:
     """Helper function that compiles the encoder of a Presto model
     and performs a warm-up on dummy data. The lru_cache decorator
     ensures caching on compute nodes to be able to actually benefit

--- a/presto/inference.py
+++ b/presto/inference.py
@@ -435,7 +435,7 @@ def compile_encoder(presto_encoder: nn.Module) -> Callable[..., Any]:
     """
 
     logger.info("Compiling Presto encoder ...")
-    presto_encoder = torch.compile(presto_encoder)
+    presto_encoder = torch.compile(presto_encoder)  # type: ignore
 
     logger.info("Warming-up ...")
     for _ in range(3):

--- a/presto/inference.py
+++ b/presto/inference.py
@@ -18,7 +18,7 @@ from .dataops import (
     S1_S2_ERA5_SRTM,
     DynamicWorld2020_2021,
 )
-from .dataset import WorldCerealDataset
+from .dataset import WorldCerealBase
 from .masking import BAND_EXPANSION
 from .presto import Presto
 from .utils import device, prep_dataframe
@@ -294,7 +294,7 @@ def get_presto_features(
 
     if isinstance(inarr, pd.DataFrame):
         processed_df = process_parquet(inarr)
-        test_ds = WorldCerealDataset(processed_df)
+        test_ds = WorldCerealBase(processed_df)
         dl = DataLoader(test_ds, batch_size=batch_size, shuffle=False)
         return presto_extractor._get_encodings(dl)
 

--- a/presto/inference.py
+++ b/presto/inference.py
@@ -18,7 +18,7 @@ from .dataops import (
     S1_S2_ERA5_SRTM,
     DynamicWorld2020_2021,
 )
-from .dataset import WorldCerealBase
+from .dataset import WorldCerealDataset
 from .masking import BAND_EXPANSION
 from .presto import Presto
 from .utils import device, prep_dataframe
@@ -294,8 +294,7 @@ def get_presto_features(
 
     if isinstance(inarr, pd.DataFrame):
         processed_df = process_parquet(inarr)
-        test_ds = WorldCerealBase(processed_df)
-        # test_ds = WorldCerealLabelledDataset(processed_df)
+        test_ds = WorldCerealDataset(processed_df)
         dl = DataLoader(test_ds, batch_size=batch_size, shuffle=False)
         return presto_extractor._get_encodings(dl)
 

--- a/presto/presto.py
+++ b/presto/presto.py
@@ -1,3 +1,4 @@
+import functools
 import io
 import math
 from copy import deepcopy
@@ -799,19 +800,23 @@ class Presto(nn.Module):
         return model
 
     @classmethod
+    @functools.lru_cache(maxsize=6)
     def load_pretrained(
         cls, model_path: Union[str, Path] = default_model_path, strict: bool = True
     ):
         model = cls.construct()
         model.load_state_dict(torch.load(model_path, map_location=device), strict=strict)
+
         return model
 
     @classmethod
+    @functools.lru_cache(maxsize=6)
     def load_pretrained_url(cls, presto_url: str, strict: bool = True):
         response = requests.get(presto_url)
         presto_model_layers = torch.load(io.BytesIO(response.content), map_location=device)
         model = cls.construct()
         model.load_state_dict(presto_model_layers, strict=strict)
+
         return model
 
 
@@ -877,5 +882,4 @@ def get_layer_id_for_rest_finetuning(name, num_layers):
     elif name.startswith("encoder.blocks"):
         return int(name.split(".")[2]) + 1
     else:
-        return num_layers
         return num_layers

--- a/presto/presto.py
+++ b/presto/presto.py
@@ -800,7 +800,6 @@ class Presto(nn.Module):
         return model
 
     @classmethod
-    @functools.lru_cache(maxsize=6)
     def load_pretrained(
         cls, model_path: Union[str, Path] = default_model_path, strict: bool = True
     ):

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     long_description_content_type="text/markdown",
     author="Gabriel Tseng",
     author_email="gabrieltseng95@gmail.com",
-    version="0.1.2",
+    version="0.1.3",
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: Other/Proprietary License",

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,0 +1,36 @@
+from unittest import TestCase
+
+import numpy as np
+from torch.utils.data import DataLoader
+
+from presto.dataset import WorldCerealDataset
+from presto.inference import PrestoFeatureExtractor, compile_encoder
+from presto.presto import Presto
+from presto.utils import prep_dataframe
+from tests.utils import read_test_file
+
+
+class TestInference(TestCase):
+    def test_compiled_encoder(self):
+        model = Presto.load_pretrained()
+        test_data = read_test_file()
+        df = prep_dataframe(test_data)
+        ds = WorldCerealDataset(df)
+        dl = DataLoader(
+            ds,
+            batch_size=512,
+            shuffle=False,  # keep as False!
+            num_workers=4,
+        )
+
+        # First the original uncompiled encoder
+        presto_extractor = PrestoFeatureExtractor(model, batch_size=512)
+        embeddings = presto_extractor._get_encodings(dl)
+
+        # Now compile the encoder and recompute embeddings
+        model.encoder = compile_encoder(model.encoder)
+        presto_extractor = PrestoFeatureExtractor(model, batch_size=512)
+        embeddings_compiled = presto_extractor._get_encodings(dl)
+
+        # Check that the embeddings are (almost) the same
+        np.testing.assert_allclose(embeddings, embeddings_compiled, atol=1e-5)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 import numpy as np
 from torch.utils.data import DataLoader
 
-from presto.dataset import WorldCerealDataset
+from presto.dataset import WorldCerealBase
 from presto.inference import PrestoFeatureExtractor, compile_encoder
 from presto.presto import Presto
 from presto.utils import prep_dataframe
@@ -15,7 +15,7 @@ class TestInference(TestCase):
         model = Presto.load_pretrained()
         test_data = read_test_file()
         df = prep_dataframe(test_data)
-        ds = WorldCerealDataset(df)
+        ds = WorldCerealBase(df)
         dl = DataLoader(
             ds,
             batch_size=512,


### PR DESCRIPTION
FYI @gabrieltseng

Test results of this compilation on 10,000 samples (pixels):

**without compilation:**
- warm-up time:  4s
- average inference time: 6s

**with compilation:**
- warm-up time: 37s
- average inference time: 1.75s

Preliminary conclusion: for small inference jobs, warm-up time of JIT compilation does not pay off and actually leads to an increase of inference time. However, when we'd succeed at caching the compiled (and warmed-up!) Presto encoder for larger inference jobs, a more than 3-fold reduction in inference time is observed which is quite significant. We will test this more at larger scale also to see if caching actually works, however a C++ compiler first needs to be installed in the openEO environment on CDSE before this can succeed.