### PR TITLE
Inference-bugfixes

### DIFF
--- a/presto/inference.py
+++ b/presto/inference.py
@@ -112,7 +112,7 @@ class PrestoFeatureExtractor:
                 )
                 idx_valid = values != cls._NODATAVALUE
                 values = cls._preprocess_band_values(values, presto_band)
-                eo_data[:, :, BANDS.index(presto_band)] = values
+                eo_data[:, :, BANDS.index(presto_band)] = values * idx_valid
                 mask[:, :, IDX_TO_BAND_GROUPS[presto_band]] += ~idx_valid
             else:
                 logger.warning(f"Band {org_band} not found in input data.")

--- a/presto/inference.py
+++ b/presto/inference.py
@@ -402,12 +402,13 @@ def process_parquet(df: pd.DataFrame) -> pd.DataFrame:
         (((df["timestamp"] - df["end_date"]).dt.days + 365) / 30).round().astype(int)
     )
 
+    # Now reassign start_date to the actual subset counted back from end_date
+    df["start_date"] = df["end_date"] - pd.Timedelta(days=364)
+
     df_pivot = df[(df["valid_date_ind"] >= 0) & (df["valid_date_ind"] < 12)].pivot(
         index=index_columns, columns="valid_date_ind", values=feature_columns
     )
 
-    # Now reassign start_date to the actual subset counted back from end_date
-    df["start_date"] = df["end_date"] - pd.Timedelta(days=364)
     # ----------------------------------------------------------------------------
 
     if df_pivot.empty:

--- a/presto/inference.py
+++ b/presto/inference.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Tuple, Union
 
 import numpy as np
@@ -19,6 +20,9 @@ from .dataset import WorldCerealBase
 from .masking import BAND_EXPANSION
 from .presto import Presto
 from .utils import device, prep_dataframe
+
+logger = logging.getLogger(__name__)
+
 
 # Index to band groups mapping
 IDX_TO_BAND_GROUPS = {
@@ -108,6 +112,11 @@ class PrestoFeatureExtractor:
                 values = cls._preprocess_band_values(values, presto_band)
                 eo_data[:, :, BANDS.index(presto_band)] = values
                 mask[:, :, IDX_TO_BAND_GROUPS[presto_band]] += ~idx_valid
+            else:
+                logger.warning(f"Band {org_band} not found in input data.")
+                eo_data[:, :, BANDS.index(presto_band)] = 0
+                mask[:, :, IDX_TO_BAND_GROUPS[presto_band]] = 1
+
 
         return eo_data, mask
 

--- a/presto/inference.py
+++ b/presto/inference.py
@@ -403,7 +403,7 @@ def process_parquet(df: pd.DataFrame) -> pd.DataFrame:
     )
 
     # Now reassign start_date to the actual subset counted back from end_date
-    df["start_date"] = df["end_date"] - pd.Timedelta(days=364)
+    df["start_date"] = df["end_date"] - pd.DateOffset(years=1) + pd.DateOffset(days=1)
 
     df_pivot = df[(df["valid_date_ind"] >= 0) & (df["valid_date_ind"] < 12)].pivot(
         index=index_columns, columns="valid_date_ind", values=feature_columns


### PR DESCRIPTION
Committed some bug fixes and improvements to the inference pipeline.
- the `start_date` in new parquet file was handled wrongly. 
- a warning is now logged when a Presto band is not found in the inputs
- in case a Presto band is not found, corresponding mask is set to 1