### PR TITLE
Device ambiguity issue #217

### DIFF
--- a/presto/inference.py
+++ b/presto/inference.py
@@ -201,7 +201,7 @@ def get_presto_features(
         from_url=from_url,
         strict=False,
         valid_month_as_token=use_valid_date_token,
-    )
+    ).to(device)
 
     # Compile for optimized inference. Note that warmup takes some time
     # so this is only recommended for larger inference jobs

--- a/presto/presto.py
+++ b/presto/presto.py
@@ -418,12 +418,11 @@ class Encoder(nn.Module):
         valid_month: Optional[torch.Tensor] = None,
         eval_task: bool = True,
     ):
-        # device = x.device
 
         if mask is None:
-            mask = torch.zeros_like(x, device=x.device)
+            mask = torch.zeros_like(x, device=device)
 
-        months = month_to_tensor(month, x.shape[0], x.shape[1], x.device)
+        months = month_to_tensor(month, x.shape[0], x.shape[1], device)
         month_embedding = self.month_embed(months)
         positional_embedding = repeat(
             self.pos_embed[:, : x.shape[1], :],
@@ -622,7 +621,7 @@ class Decoder(nn.Module):
         # channel group doesn't have timesteps
         num_timesteps = int((x.shape[1] - 2) / (num_channel_groups - 1))
         srtm_index = self.band_group_to_idx["SRTM"] * num_timesteps
-        months = month_to_tensor(month, x.shape[0], num_timesteps, x.device)
+        months = month_to_tensor(month, x.shape[0], num_timesteps, device)
 
         # when we expand the encodings, each channel_group gets num_timesteps
         # encodings. However, there is only one SRTM token so we remove the
@@ -676,7 +675,7 @@ class Decoder(nn.Module):
         srtm_index = self.band_group_to_idx["SRTM"] * num_timesteps
         srtm_token = x[:, srtm_index : srtm_index + 1, :]
 
-        mask = torch.full((x.shape[1],), True, device=x.device)
+        mask = torch.full((x.shape[1],), True, device=device)
         mask[torch.tensor(srtm_index)] = False
         x = x[:, mask]
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -82,12 +82,12 @@ class TestDataset(TestCase):
 
         with torch.no_grad():
             _ = model(
-                x=torch.from_numpy(eo).float()[:num_vals],
-                dynamic_world=torch.from_numpy(dw).long()[:num_vals],
-                latlons=torch.from_numpy(latlons).float()[:num_vals],
-                mask=torch.from_numpy(mask).int()[:num_vals],
-                month=torch.from_numpy(months).long()[:num_vals],
-                valid_month=torch.from_numpy(valid_months).long()[:num_vals],
+                x=torch.from_numpy(eo).float()[:num_vals].to(device),
+                dynamic_world=torch.from_numpy(dw).long()[:num_vals].to(device),
+                latlons=torch.from_numpy(latlons).float()[:num_vals].to(device),
+                mask=torch.from_numpy(mask).int()[:num_vals].to(device),
+                month=torch.from_numpy(months).long()[:num_vals].to(device),
+                valid_month=torch.from_numpy(valid_months).long()[:num_vals].to(device),
             )
 
     def test_spatial_dataset_without_valid_month_token(self):
@@ -105,11 +105,11 @@ class TestDataset(TestCase):
 
         with torch.no_grad():
             _ = model(
-                x=torch.from_numpy(eo).float()[:num_vals],
-                dynamic_world=torch.from_numpy(dw).long()[:num_vals],
-                latlons=torch.from_numpy(latlons).float()[:num_vals],
-                mask=torch.from_numpy(mask).int()[:num_vals],
-                month=torch.from_numpy(months).long()[:num_vals],
+                x=torch.from_numpy(eo).float()[:num_vals].to(device),
+                dynamic_world=torch.from_numpy(dw).long()[:num_vals].to(device),
+                latlons=torch.from_numpy(latlons).float()[:num_vals].to(device),
+                mask=torch.from_numpy(mask).int()[:num_vals].to(device),
+                month=torch.from_numpy(months).long()[:num_vals].to(device),
             )
 
     def test_combine_predictions(self):

--- a/tests/test_presto.py
+++ b/tests/test_presto.py
@@ -623,7 +623,9 @@ class TestPrestoEndToEnd(TestCase):
             x, orig_indices, upd_mask = self.forward_encoder(
                 x, dynamic_world, mask, eval_task=False
             )
-            x = self.model.decoder.add_masked_tokens(x.to(device), orig_indices.to(device), upd_mask.to(device))
+            x = self.model.decoder.add_masked_tokens(
+                x.to(device), orig_indices.to(device), upd_mask.to(device)
+            )
             return self.model.decoder.reconstruct_inputs(x)
 
         batch_size, timesteps = 2, 3

--- a/tests/test_presto.py
+++ b/tests/test_presto.py
@@ -398,7 +398,7 @@ class TestPresto(TestCase):
             dim=1,
         )
 
-        eo, dw = model.reconstruct_inputs(x)
+        eo, dw = model.reconstruct_inputs(x.to(device))
 
         for group, idxs in BANDS_GROUPS_IDX.items():
             relevant_vals = eo[:, :, idxs]
@@ -563,6 +563,9 @@ class TestPrestoEndToEnd(TestCase):
         def forward_encoder(x, dynamic_world, mask, encoder, eval_task=False):
             # THIS CODE IS FROM WITHIN THE PRESTO FUNCTION, WITH SLIGHT MODIFICATIONS #
             # if the presto code changes this will need to as well #
+
+            # print(f"initial x device: {x.device}")
+
             all_tokens, all_masks = [], []
 
             for channel_group, channel_idxs in encoder.band_groups.items():
@@ -587,15 +590,16 @@ class TestPrestoEndToEnd(TestCase):
 
             x = torch.cat(all_tokens, dim=1)  # [batch, timesteps, embedding_dim]
             mask = torch.cat(all_masks, dim=1)  # [batch, timesteps]
+            # print(f"redefined x device: {x.device}")
             x, orig_indices, upd_mask = encoder.mask_tokens(x, mask)
 
             # append latlon tokens
             latlon_tokens = torch.ones((x.shape[0], 1, embedding_size)) * -1
             x = torch.cat((latlon_tokens, x), dim=1)
-            upd_mask = torch.cat((torch.zeros(x.shape[0])[:, None].to(device), upd_mask), dim=1)
+            upd_mask = torch.cat((torch.zeros(x.shape[0])[:, None], upd_mask), dim=1)
             orig_indices = torch.cat(
                 (
-                    torch.zeros(upd_mask.shape[0])[:, None].to(device).int(),
+                    torch.zeros(upd_mask.shape[0])[:, None].int(),
                     orig_indices + 1,
                 ),
                 dim=1,
@@ -608,17 +612,18 @@ class TestPrestoEndToEnd(TestCase):
             return x, orig_indices, upd_mask
 
         cls.forward_encoder = partial(forward_encoder, encoder=model.encoder)
+        # cls.forward_encoder = partial(forward_encoder, encoder=model.encoder.to(device))
         cls.model = model
 
     def test_masking_and_unmasking_end_to_end(self):
         def forward(x, dynamic_world, mask):
             # THIS CODE IS FROM WITHIN THE PRESTO FUNCTION, WITH SLIGHT MODIFICATIONS #
             # if the presto code changes this will need to as well #
-            self.model = self.model.to(device)
+            # self.model = self.model
             x, orig_indices, upd_mask = self.forward_encoder(
                 x, dynamic_world, mask, eval_task=False
             )
-            x = self.model.decoder.add_masked_tokens(x, orig_indices, upd_mask)
+            x = self.model.decoder.add_masked_tokens(x.to(device), orig_indices.to(device), upd_mask.to(device))
             return self.model.decoder.reconstruct_inputs(x)
 
         batch_size, timesteps = 2, 3
@@ -632,7 +637,7 @@ class TestPrestoEndToEnd(TestCase):
         dynamic_world = torch.ones((batch_size, timesteps)) * dw_value
         mask = torch.zeros_like(x)
 
-        eo, dw = forward(x.to(device), dynamic_world.to(device), mask.to(device))
+        eo, dw = forward(x, dynamic_world, mask)
         for group, idxs in BANDS_GROUPS_IDX.items():
             relevant_vals = eo[:, :, idxs]
             self.assertTrue(


### PR DESCRIPTION
- edited _presto.py_ to take one device everywhere rather than to infer device from a variable 
- in _inference.py_, explicitly send the model to device in _get_presto_features_ function
- adapted tests